### PR TITLE
Fix style of notification

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,7 @@
 .notification {
 	display: block;
 	padding: 7px 15px 50px 15px;
+	line-height: normal;
 }
 .notification:not(:last-child) {
 	border-bottom: 1px solid rgb(238, 238, 238);
@@ -49,10 +50,6 @@
 	opacity: 0.3;
 }
 
-.notification:hover {
-	background-color: #f8f8f8;
-}
-
 .notification-delete:hover {
 	opacity: 0.8 !important;
 	cursor: pointer;
@@ -95,6 +92,10 @@
 	padding: 0;
 }
 
+.notification .notification-actions .action-button.primary{
+	color: #fff;
+}
+
 .notification .notification-actions:first-child {
 	margin-left: auto;
 }
@@ -102,6 +103,9 @@
 .notification .notification-subject {
 	display: inline-block;
 	margin-right: 10px;
+}
+.notification .notification-subject:hover {
+	background-color: #f8f8f8;
 }
 
 .notification .notification-message {

--- a/css/styles.css
+++ b/css/styles.css
@@ -45,8 +45,8 @@
 .notification:hover > .notification-delete{
 	display: block !important;
 	position: absolute;
-	top: 4px;
-	right: 9px;
+	top: 7px;
+	right: 14px;
 	opacity: 0.3;
 }
 
@@ -103,9 +103,10 @@
 .notification .notification-subject {
 	display: inline-block;
 	margin-right: 10px;
+	opacity: .57;
 }
 .notification .notification-subject:hover {
-	background-color: #f8f8f8;
+	opacity: 1;
 }
 
 .notification .notification-message {

--- a/js/notification.js
+++ b/js/notification.js
@@ -124,7 +124,7 @@
 			_.each(actionsData, function(actionData) {
 				// FIXME: use handlebars template
 				actions.append(
-					'<button class="action-button' + (actionData.primary ? ' primary': '') + '" data-type="' + escapeHTML(actionData.type) + '" ' +
+					'<button class="action-button' + (actionData.primary ? ' primary pull-right': '') + '" data-type="' + escapeHTML(actionData.type) + '" ' +
 					'data-href="'+escapeHTML(actionData.link)+'">'+escapeHTML(actionData.label)+'</button>'
 				);
 				// TODO create event handler on click for given action type


### PR DESCRIPTION
* normal line-height
* no gray background on hover
* underline on hover to detect that it is clickable
* pull primary buttons to right
* white color for primary button instead of grey (looked disabled)
* for https://github.com/nextcloud/server/issues/735

Before:
![bildschirmfoto 2016-08-10 um 13 50 36](https://cloud.githubusercontent.com/assets/245432/17552718/c5899172-5f01-11e6-97ce-28ad3dcc502e.png)
After:
![bildschirmfoto 2016-08-10 um 13 49 49](https://cloud.githubusercontent.com/assets/245432/17552708/b86aad82-5f01-11e6-9db8-56e9796fda05.png)

--
hovered state

Before:
![bildschirmfoto 2016-08-10 um 13 50 41](https://cloud.githubusercontent.com/assets/245432/17552726/d21a3c5c-5f01-11e6-89d3-b794409969e0.png)
After:
![bildschirmfoto 2016-08-10 um 13 50 00](https://cloud.githubusercontent.com/assets/245432/17552729/d747657e-5f01-11e6-8e80-53add4ed92f3.png)


cc @nextcloud/designers @schiessle @rullzer @LukasReschke 