### PR TITLE
Fix dismissing a notification

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -51,7 +51,7 @@
 
 		/** @type {string} */
 		_notificationTemplate: '' +
-		'<div class="notification" data-id="{{id}}" data-timestamp="{{timestamp}}">' +
+		'<div class="notification" data-id="{{notification_id}}" data-timestamp="{{timestamp}}">' +
 		'  {{#if link}}' +
 		'    {{#if icon}}<img src="{{icon}}" style="float: left;">{{/if}}' +
 		'    <a href="{{link}}" class="notification-subject">{{{subject}}}</a>' +


### PR DESCRIPTION
Allows to press the ✖️  on a notification again.

@Ivansss the problem we saw with the spreed notification
cc @MorrisJobke 