### PR TITLE
Do not show unparsed HTML in the desktop notification

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -312,8 +312,8 @@
 		 * @param {OCA.Notifications.Notification} notification
 		 */
 		_createWebNotification: function (notification) {
-			var n = new Notification(notification.getSubject(), {
-				title: notification.getSubject(),
+			var n = new Notification(notification.getPlainSubject(), {
+				title: notification.getPlainSubject(),
 				lang: OC.getLocale(),
 				body: notification.getMessage(),
 				icon: notification.getIcon(),

--- a/js/notification.js
+++ b/js/notification.js
@@ -66,6 +66,10 @@
 				);
 			}
 
+			return this.getPlainSubject();
+		},
+
+		getPlainSubject: function() {
 			return this.data.subject;
 		},
 
@@ -112,7 +116,8 @@
 		 * @param {Function} template
 		 */
 		renderElement: function(template) {
-			return template(_.extend(this.data, {
+			var temp = _.extend({}, this.data);
+			return template(_.extend(temp, {
 				subject: this.getSubject(),
 				link: this.getLink(),
 				message: this.getMessage()


### PR DESCRIPTION
### Steps
1. Login as user 2
2. As user 1 mention user 2 in a comment
3. The next polling in the background shows a desktop-HTML notification
4. The notification text should not contain any mark up

### Acctually
Strings starts with
```
<div class="avatar" ...
```

@LukasReschke the thing we just debugged
@MorrisJobke 