### PR TITLE
add some more spacing between the content and the close button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -36,6 +36,7 @@
 .notification {
 	color: black;
 	position: relative;
+	clear: both;
 }
 
 img.notification-icon {
@@ -93,15 +94,16 @@ img.notification-icon {
 	padding: 0 10px;
 	box-shadow: none;
 	margin: 0;
-	float: left;
 }
 
 .notification .notification-actions {
-	float:right;
 	padding: 0;
+	display: inline-block;
+	width: 100%;
+	margin: -6px 0;
 }
 
-.notification .notification-actions .action-button.primary{
+.notification .notification-actions .action-button.primary {
 	color: #fff;
 }
 
@@ -136,7 +138,7 @@ img.notification-icon {
 }
 
 .notification strong,
-.notification .notification-subject a {
+.notification .notification-subject a:not(.full-subject-link) {
 	font-weight: bold;
 	opacity: 2;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,6 @@
 .notification {
 	display: block;
-	padding: 7px 15px 50px 15px;
+	padding: 15px 15px 50px 15px;
 	line-height: 1.75em;
 }
 .notification:not(:last-child) {
@@ -117,7 +117,7 @@
 .notification img {
 	max-width: 32px;
 	max-height: 32px;
-	margin: 0 5px 5px 0;
+	margin: 0 0 5px 0;
 }
 
 .notification .avatar {

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,6 @@
 .notification {
 	display: block;
-	padding: 15px 15px 50px 15px;
+	padding: 12px;
 	line-height: 1.75em;
 }
 .notification:not(:last-child) {
@@ -38,15 +38,24 @@
 	position: relative;
 }
 
+img.notification-icon {
+	width: 32px;
+	float: left;
+}
+
+.notification-subject.has-icon {
+	margin-left: 45px;
+}
+
 .notification .notification-empty {
 	color: #999;
 }
 
-.notification:hover > .notification-delete{
+.notification:hover > .notification-delete {
 	display: block !important;
 	position: absolute;
 	top: 7px;
-	right: 14px;
+	right: 12px;
 	opacity: 0.3;
 }
 
@@ -101,8 +110,7 @@
 }
 
 .notification .notification-subject {
-	display: inline-block;
-	margin-right: 10px;
+	margin-right: 20px;
 }
 
 .notification .notification-message {
@@ -114,10 +122,11 @@
 	opacity: 1;
 }
 
-.notification img {
+.notification .notification-message img,
+.notification .notification-subject img {
 	max-width: 32px;
 	max-height: 32px;
-	margin: 0 0 5px 0;
+	margin: 0 5px 5px 0;
 }
 
 .notification .avatar {

--- a/js/app.js
+++ b/js/app.js
@@ -54,7 +54,7 @@
 		'<div class="notification" data-id="{{notification_id}}" data-timestamp="{{timestamp}}">' +
 		'  {{#if link}}' +
 		'    {{#if icon}}<img src="{{icon}}" class="notification-icon">{{/if}}' +
-		'    <a href="{{link}}" class="notification-subject {{#if icon}}has-icon{{/if}}">{{{subject}}}</a>' +
+		'    <div class="notification-subject {{#if icon}}has-icon{{/if}}"><a href="{{link}}" class="full-subject-link">{{{subject}}}</a></div>' +
 		'  {{else}}' +
 		'    {{#if icon}}<img src="{{icon}}" class="notification-icon">{{/if}}' +
 		'    <div class="notification-subject {{#if icon}}has-icon{{/if}}">{{{subject}}}</div>' +

--- a/js/app.js
+++ b/js/app.js
@@ -53,11 +53,11 @@
 		_notificationTemplate: '' +
 		'<div class="notification" data-id="{{notification_id}}" data-timestamp="{{timestamp}}">' +
 		'  {{#if link}}' +
-		'    {{#if icon}}<img src="{{icon}}" style="float: left;">{{/if}}' +
-		'    <a href="{{link}}" class="notification-subject">{{{subject}}}</a>' +
+		'    {{#if icon}}<img src="{{icon}}" class="notification-icon">{{/if}}' +
+		'    <a href="{{link}}" class="notification-subject {{#if icon}}has-icon{{/if}}">{{{subject}}}</a>' +
 		'  {{else}}' +
-		'    {{#if icon}}<img src="{{icon}}" style="float: left;">{{/if}}' +
-		'    <div class="notification-subject">{{{subject}}}</div>' +
+		'    {{#if icon}}<img src="{{icon}}" class="notification-icon">{{/if}}' +
+		'    <div class="notification-subject {{#if icon}}has-icon{{/if}}">{{{subject}}}</div>' +
 		'  {{/if}}' +
 		'  <div class="notification-message">{{{message}}}</div>' +
 		'  <div class="notification-actions">' +


### PR DESCRIPTION
This is how it looked before:

![screenshot1](https://cloud.githubusercontent.com/assets/1589737/20496543/f0e20906-b025-11e6-84d7-c016d7aae108.png)

looks quite squeezed, the text and the close button.

This is how it looks now: 

![screenshot2](https://cloud.githubusercontent.com/assets/1589737/20496562/0efa011e-b026-11e6-8dd3-50f2afe46598.png)

cc @nextcloud/designers @nickvergessen 
