### PR TITLE
Add the timestamp to the notification

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,7 +1,7 @@
 .notification {
 	display: block;
-	padding: 12px;
-	line-height: 1.75em;
+	padding: 16px 12px;
+	line-height: 1em;
 }
 .notification:not(:last-child) {
 	border-bottom: 1px solid rgb(238, 238, 238);
@@ -49,6 +49,7 @@ img.notification-icon {
  * Vertical alignment from http://stackoverflow.com/a/39923209
  */
 .notification-subject {
+	padding-top: 12px;
 	position: relative;
 }
 
@@ -88,6 +89,15 @@ img.notification-icon {
 
 .notification-delete img, .notifications-button img {
 	cursor: pointer;
+}
+
+.notification-time {
+	text-align: right;
+	opacity: 0.5;
+	padding-right: 32px;
+	margin-top: -7px;
+	position: absolute;
+	right: 0;
 }
 
 .notifications-button {
@@ -138,7 +148,7 @@ img.notification-icon {
 
 .notification .notification-message {
 	line-height: 20px;
-	padding-bottom: 5px;
+	padding-bottom: 16px;
 	opacity: .57;
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -52,6 +52,7 @@
 		/** @type {string} */
 		_notificationTemplate: '' +
 		'<div class="notification" data-id="{{notification_id}}" data-timestamp="{{timestamp}}">' +
+		'  <span class="notification-time has-tooltip live-relative-timestamp" data-timestamp="{{timestamp}}" title="{{absoluteDate}}">{{relativeDate}}</span>' +
 		'  {{#if link}}' +
 		'    <div class="notification-subject">' +
 		'      <a href="{{link}}" class="full-subject-link">' +
@@ -356,8 +357,6 @@
 			var $element = $(notification.renderElement(this.notificationTemplate));
 
 			$element.find('.avatar').each(function() {
-				console.log('avatar');
-				console.log(arguments);
 				var element = $(this);
 				if (element.data('user-display-name')) {
 					element.avatar(element.data('user'), 21, undefined, false, undefined, element.data('user-display-name'));

--- a/js/notification.js
+++ b/js/notification.js
@@ -47,7 +47,11 @@
 		},
 
 		getTimestamp: function() {
-			return moment(this.data.datetime).format('X');
+			if (_.isUndefined(this.data.timestamp)) {
+				this.data.timestamp = moment(this.data.datetime).format('X') * 1000;
+			}
+
+			return this.data.timestamp;
 		},
 
 		getObjectType: function() {
@@ -120,7 +124,10 @@
 			return template(_.extend(temp, {
 				subject: this.getSubject(),
 				link: this.getLink(),
-				message: this.getMessage()
+				message: this.getMessage(),
+				timestamp: this.getTimestamp(),
+				relativeDate: OC.Util.relativeModifiedDate(this.getTimestamp()),
+				absoluteDate: OC.Util.formatDate(this.getTimestamp())
 			}));
 		}
 	};


### PR DESCRIPTION
@jancborchardt for testing just mention an account in a comment.

Please also make sure that it works good with long/short subject/messages. You can adjust that in https://github.com/nextcloud/notifications/blob/926a9d9e57cbd022546208f137ea8fb3618d81e7/js/app.js#L55-L63 by replacing `{{{subject}}}` and `{{{message}}}`

You can also use that same trick to work on https://github.com/nextcloud/notifications/issues/42 properly

Fix #46 