### PR TITLE
Fix sizing of the icon

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -103,8 +103,8 @@ img.notification-icon {
 .notifications-button {
 	position: relative;
 	float: right;
-	width: 21px;
-	height: 21px;
+	width: 16px;
+	height: 16px;
 	display: block;
 	border-radius: 50%;
 	text-align: center;


### PR DESCRIPTION
-  for nextcloud/server#2924

cc @ChristophWurst @nickvergessen 

Before:

<img width="293" alt="bildschirmfoto 2017-01-23 um 12 03 10" src="https://cloud.githubusercontent.com/assets/245432/22216756/f0018b26-e165-11e6-8592-16640a765736.png">

After:

<img width="298" alt="bildschirmfoto 2017-01-23 um 12 17 58" src="https://cloud.githubusercontent.com/assets/245432/22216775/026e3548-e166-11e6-9942-e66529f4ab9c.png">
