### PR TITLE
move to right of search icon in header

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -91,7 +91,7 @@
 			this.$container = this.$notifications.find('.notification-container');
 
 			// Add to the UI
-			$('form.searchbox').before(this.$notifications);
+			$('form.searchbox').after(this.$notifications);
 
 			// Initial call to the notification endpoint
 			this.initialFetch();


### PR DESCRIPTION
Because the search box expands to the left, it’s strange if there’s an icon left of it.

Please review @nickvergessen @nextcloud/javascript 