### PR TITLE
fix placement of menu arrow with Contacts menu addition

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -168,7 +168,7 @@ img.notification-icon {
 
 /* Menu arrow */
 .notification-container:after {
-	right: 57px;
+	right: 101px;
 }
 
 .notification-wrapper {


### PR DESCRIPTION
This fixes the misplacement as soon as the Contacts menu is merged: https://github.com/nextcloud/server/pull/3233