### PR TITLE
Fix shadow and "Notifications" text flashing on load

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -162,10 +162,6 @@ img.notification-icon {
 	opacity: 1;
 }
 
-.notification-container {
-	box-shadow: 0 1px 10px rgba(50, 50, 50, .7);
-}
-
 /* Menu arrow */
 .notification-container:after {
 	right: 101px;

--- a/js/app.js
+++ b/js/app.js
@@ -38,7 +38,7 @@
 		_containerTemplate: '' +
 		'<div class="notifications hidden">' +
 		'  <div class="notifications-button menutoggle">' +
-		'    <img class="svg" alt="' + t('notifications', 'Notifications') + '"' +
+		'    <img class="svg" alt="" title="' + t('notifications', 'Notifications') + '"' +
 		'      src="' + OC.imagePath('notifications', 'notifications') + '">' +
 		'  </div>' +
 		'  <div class="notification-container">' +


### PR DESCRIPTION
Removed the extra shadow which was darker than the core shadow.

Also moved the »Notifications« text from alt to title so it doesn’t flash in the header on load, but still works for accessibility.

Please review @nickvergessen @nextcloud/designers 