### PR TITLE
Make the subject of push notifications decryptable

### DIFF
--- a/lib/Push.php
+++ b/lib/Push.php
@@ -169,7 +169,7 @@ class Push {
 		}
 
 		openssl_sign($encryptedSubject, $signature, $userKey->getPrivate(), OPENSSL_ALGO_SHA512);
-		$base64EncryptedSubject = base64_encode(hash('sha512', $encryptedSubject, true));
+		$base64EncryptedSubject = base64_encode($encryptedSubject);
 		$base64Signature = base64_encode($signature);
 
 		return [


### PR DESCRIPTION
If we hash the subject (like we currently do) there is no way to recover it on the proxy.
However now the proxy is broken, because:
1. It expects a given message length
2. It expects the message to be hashed

Therefor it requires: https://github.com/nextcloud-gmbh/push-notification-proxy/pull/13