### PR TITLE
Allow screenreaders to see close icon

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -75,7 +75,7 @@
 		'    {{/each}}' +
 		'  </div>' +
 		'  <div style="display: none;" class="notification-delete">' +
-		'    <div class="icon icon-close svg" title="' + t('notifications', 'Dismiss') + '"></div>' +
+		'    <div class="icon icon-close svg"  role="button" aria-label="' + t('notifications', 'Dismiss') + '" title="' + t('notifications', 'Dismiss') + '"></div>' +
 		'  </div>' +
 		'</div>',
 


### PR DESCRIPTION
Currently it is impossible for screeenreader users to dismiss notifications due to #76 

This adds a role and an ARIA label for the div that is hopefully caught by most screenreaders.

Unfortunately I'm lost trying to use a screen reader since I couldn't even get notification text focused or read even though they are screenreader accessible, so I couldn't test this myself and will try to get it tested.