### PR TITLE
Fix "tooltips shown in a notification alter its layout"

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -384,6 +384,7 @@
 			});
 
 			$element.find('.has-tooltip').tooltip({
+				container: this.$container.find('.notification-wrapper'),
 				placement: 'bottom'
 			});
 


### PR DESCRIPTION
Fixes #100

By default, `tooltip()` adds the tooltip element to the element in which the function is called. If a `container` option is provided the tooltip is added instead to the given element, although visually it will be shown for the element in which the function is called.

The tooltips shown in notifications, when shown near the bottom, could cause a scroll bar to appear in the notification wrapper, which in turn could change the layout of the notification and cause a "jumpy" effect. Now the tooltip is added to the notification wrapper, which prevents the scroll bar from appearing when the tooltip is shown (even if the tooltip overflows the notification wrapper).

This also fixes a wrong HTML markup, as the tooltip is shown with a `div` element, but it was added to a `span` element; now it is added to another `div` element.

To be honest I do not fully understand why changing the parent element of the tooltip to the notification wrapper prevents the scroll bar from appearing, even if the tooltip overflows the wrapper (which can be tested by changing the tooltip placement to the top and showing the tooltip for the date), so @nextcloud/designers may want to review this ;-)

Tooltip hidden:
![notification-tooltip-hidden](https://user-images.githubusercontent.com/26858233/33387846-a8f862fa-d52e-11e7-9653-a5f14b667a2a.png)

Tooltip shown, before:
![notification-tooltip-shown](https://user-images.githubusercontent.com/26858233/33387850-ab14079c-d52e-11e7-82cb-adb3a9b5a85d.png)

Tooltip shown, after:
![notification-tooltip-shown-after](https://user-images.githubusercontent.com/26858233/33387854-ad1a5000-d52e-11e7-8689-5239a7066a4e.png)
