### PR TITLE
Add the missing menu arrow on mobile

### DIFF
--- a/js-src/components/root.vue
+++ b/js-src/components/root.vue
@@ -79,7 +79,7 @@
 			this._$icon = $(this.$refs.icon);
 
 			// Bind the button click event
-			OC.registerMenu($(this.$refs.button), $(this.$refs.container));
+			OC.registerMenu($(this.$refs.button), $(this.$refs.container), undefined, true);
 		},
 
 		updated: function() {


### PR DESCRIPTION
Signed-off-by: Joas Schilling <coding@schilljs.com>