### PR TITLE
Fix "Argument 1 passed to OC\Authentication\Token\Manager::getTokenBy…

### DIFF
--- a/lib/Controller/PushController.php
+++ b/lib/Controller/PushController.php
@@ -106,6 +106,9 @@ class PushController extends OCSController {
 		}
 
 		$tokenId = $this->session->get('token-id');
+		if (!\is_int($tokenId)) {
+			return new DataResponse(['message' => 'INVALID_SESSION_TOKEN'], Http::STATUS_BAD_REQUEST);
+		}
 		try {
 			$token = $this->tokenProvider->getTokenById($tokenId);
 		} catch (InvalidTokenException $e) {


### PR DESCRIPTION
…Id() must be of the type integer, null given"
Worked on 13 because it just through the InvalidTokenException there.

Fix https://sentry.rullzer.com/sentry/nextcloud/issues/80/