### PR TITLE
Fix notification body text alignment and text contrast

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -131,7 +131,8 @@
 	.notification-message,
 	.notification-full-message {
 		line-height: 20px;
-		opacity: .57;
+		padding-left: 42px; // 32px icon + 10px title padding
+		color: var(--color-text-maxcontrast);
 
 		& > .collapsed {
 			overflow: hidden;


### PR DESCRIPTION
- Notifications text flush left with the title (moved a bit right)
- Proper contrast for notifications detail text

Before:
![Notifications old](https://user-images.githubusercontent.com/925062/61279010-95767b80-a7b5-11e9-81c3-d7185a2ab170.png)

After:
![Notifications new](https://user-images.githubusercontent.com/925062/61279012-960f1200-a7b5-11e9-924b-741fd588a9a6.png)


Please review @nextcloud/designers 