### PR TITLE
The token id is an int

### DIFF
--- a/lib/Controller/PushController.php
+++ b/lib/Controller/PushController.php
@@ -154,7 +154,7 @@ class PushController extends OCSController {
 			return new DataResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
-		$tokenId = $this->session->get('token-id');
+		$tokenId = (int)$this->session->get('token-id');
 		try {
 			$token = $this->tokenProvider->getTokenById($tokenId);
 		} catch (InvalidTokenException $e) {


### PR DESCRIPTION
Else an exception gets thrown on the next line since `get` returns a string. But `getTokenById` expects an int.