### PR TITLE
Fix header icon hover & focus feedback

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -11,7 +11,7 @@
 
 	&:hover,
 	&:focus {
-		opacity: 1;
+		opacity: 1 !important;
 	}
 
 	&.hasNotifications {
@@ -181,7 +181,7 @@
 
 	.notification-actions {
 		overflow: hidden;
-		
+
 		.action-button.primary {
 			color: var(--color-primary-text);
 		}


### PR DESCRIPTION
The notifications icon was the only icon in the header which didn’t have any hover/focus feedback, or rather the code was not working as intended. :)

Please review @nickvergessen @jakobroehrl @juliushaertl @skjnldsv 

I would say this is also good to backport to stable17 as it is an accessibility fix.