### PR TITLE
Do not send push notifications when nothing was deleted

### DIFF
--- a/lib/Controller/EndpointController.php
+++ b/lib/Controller/EndpointController.php
@@ -164,8 +164,10 @@ class EndpointController extends OCSController {
 			return new DataResponse(null, Http::STATUS_NOT_FOUND);
 		}
 
-		$this->handler->deleteById($id, $this->getCurrentUser());
-		$this->push->pushDeleteToDevice($this->getCurrentUser(), $id);
+		$deleted = $this->handler->deleteById($id, $this->getCurrentUser());
+		if ($deleted) {
+			$this->push->pushDeleteToDevice($this->getCurrentUser(), $id);
+		}
 		return new DataResponse();
 	}
 
@@ -175,8 +177,10 @@ class EndpointController extends OCSController {
 	 * @return DataResponse
 	 */
 	public function deleteAllNotifications(): DataResponse {
-		$this->handler->deleteByUser($this->getCurrentUser());
-		$this->push->pushDeleteToDevice($this->getCurrentUser(), 0);
+		$deletedSomething = $this->handler->deleteByUser($this->getCurrentUser());
+		if ($deletedSomething) {
+			$this->push->pushDeleteToDevice($this->getCurrentUser(), 0);
+		}
 		return new DataResponse();
 	}
 

--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -117,15 +117,16 @@ class Handler {
 	 * Delete the notification of a given user
 	 *
 	 * @param string $user
+	 * @return bool
 	 */
-	public function deleteByUser(string $user) {
+	public function deleteByUser(string $user): bool {
 		$notification = $this->manager->createNotification();
 		try {
 			$notification->setUser($user);
 		} catch (\InvalidArgumentException $e) {
-			return;
+			return false;
 		}
-		$this->delete($notification);
+		return !empty($this->delete($notification));
 	}
 
 	/**
@@ -133,13 +134,14 @@ class Handler {
 	 *
 	 * @param int $id
 	 * @param string $user
+	 * @return bool
 	 */
-	public function deleteById(int $id, string $user) {
+	public function deleteById(int $id, string $user): bool {
 		$sql = $this->connection->getQueryBuilder();
 		$sql->delete('notifications')
 			->where($sql->expr()->eq('notification_id', $sql->createNamedParameter($id)))
 			->andWhere($sql->expr()->eq('user', $sql->createNamedParameter($user)));
-		$sql->execute();
+		return (bool) $sql->execute();
 	}
 
 	/**


### PR DESCRIPTION
The iOS App always sent an API request when it deleted a notification.
By accident this was also done when it did the delete caused by a delete-push
Until now the notificiations app always sent a delete-push in case of an API
call. Meaning this circled all the time.
So now we only send a push if something was actually deleted.

Ref https://github.com/nextcloud/ios/issues/1029