### PR TITLE
Adjust notification wrapper to menu styles

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -34,12 +34,12 @@
 	right: 13px;
 	width: 350px;
 	max-width: 90%;
-	min-height: 200px;
+	min-height: 210px;
+	height: 210px;
 
 	.notification-wrapper {
 		display: flex;
 		flex-direction: column;
-		overflow-y: auto;
 		max-height: 260px;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/18392 as well as a duplicate scroll bar since notifications are using the .header-right .menu styles, the scroll area is handled by the parent container.