### PR TITLE
Prevent delete for impersonated users

### DIFF
--- a/lib/Controller/EndpointController.php
+++ b/lib/Controller/EndpointController.php
@@ -164,6 +164,10 @@ class EndpointController extends OCSController {
 			return new DataResponse(null, Http::STATUS_NOT_FOUND);
 		}
 
+		if ($this->session->getImpersonatingUserID() !== null) {
+			return new DataResponse(null, Http::STATUS_FORBIDDEN);
+		}
+
 		try {
 			$deleted = $this->handler->deleteById($id, $this->getCurrentUser());
 
@@ -182,6 +186,10 @@ class EndpointController extends OCSController {
 	 * @return DataResponse
 	 */
 	public function deleteAllNotifications(): DataResponse {
+		if ($this->session->getImpersonatingUserID() !== null) {
+			return new DataResponse(null, Http::STATUS_FORBIDDEN);
+		}
+
 		$deletedSomething = $this->handler->deleteByUser($this->getCurrentUser());
 		if ($deletedSomething) {
 			$this->push->pushDeleteToDevice($this->getCurrentUser(), 0);


### PR DESCRIPTION
cc @cagdasbas for https://github.com/nextcloud/impersonate/pull/84

Summary:
Impersonate will send a notification to the user soon to make them aware. So the admin should not be able to delete the notification.