### PR TITLE
Allow to test push notifications

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -37,5 +37,6 @@
 
 	<commands>
 		<command>OCA\Notifications\Command\Generate</command>
+		<command>OCA\Notifications\Command\TestPush</command>
 	</commands>
 </info>

--- a/lib/App.php
+++ b/lib/App.php
@@ -25,6 +25,7 @@ namespace OCA\Notifications;
 use OCA\Notifications\Exceptions\NotificationNotFoundException;
 use OCP\Notification\IApp;
 use OCP\Notification\INotification;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class App implements IApp {
 	/** @var Handler */
@@ -35,6 +36,10 @@ class App implements IApp {
 	public function __construct(Handler $handler, Push $push) {
 		$this->handler = $handler;
 		$this->push = $push;
+	}
+
+	public function setOutput(OutputInterface $output): void {
+		$this->push->setOutput($output);
 	}
 
 	/**

--- a/lib/Notifier/AdminNotifications.php
+++ b/lib/Notifier/AdminNotifications.php
@@ -74,7 +74,7 @@ class AdminNotifications implements INotifier {
 	 * @throws AlreadyProcessedException When the notification is not needed anymore and should be deleted
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
-		if ($notification->getApp() !== 'admin_notifications') {
+		if ($notification->getApp() !== 'admin_notifications' && $notification->getApp() !== 'admin_notification_talk') {
 			throw new \InvalidArgumentException('Unknown app');
 		}
 


### PR DESCRIPTION
Example output:

```
$ occ notification:test-push admin 
Trying to push to 2 devices

Language is set to en
Private user key size: 1704
Public user key size: 451

Device token:9
Device public key size: 451
Data to encrypt is: {"nid":61,"app":"admin_notifications","subject":"Testing push notifications","type":"admin_notifications","id":"5e95bfdb"}
Signed encrypted push subject

Device token:11
Skipping talk device for non-talk notification
```


```
$ occ notification:test-push admin --talk
Trying to push to 2 devices

Language is set to en
Private user key size: 1704
Public user key size: 451

Device token:9
Skipping other device for talk notification because a talk app is available

Device token:11
Device public key size: 451
Data to encrypt is: {"nid":62,"app":"admin_notification_talk","subject":"Testing push notifications","type":"admin_notifications","id":"5e95bfdd"}
Signed encrypted push subject
```

Should help to find the problems e.g. with #619 