### PR TITLE
Fix/hyphens on long words

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -121,8 +121,7 @@
 			align-self: flex-start;
 		}
 
-		& > span.text,
-		& > a > span.text {
+		& > .text {
 			padding-left: 10px;
 			hyphens: auto;
 		}

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -124,7 +124,7 @@
 		& > span.text,
 		& > a > span.text {
 			padding-left: 10px;
-			line-break: anywhere;
+			hyphens: auto;
 		}
 	}
 


### PR DESCRIPTION
Hi there,
I'm proposing a CSS fix on hyphenating long words instead of truncating. It's using browsers' hyphens dictionaries. Most of them know how to truncate the english language but only Firefox and Safari are good with the others. Still I think this is better than truncating words anywhere. Maybe we could make this box larger?
What do you think about that?

Before:
![before](https://user-images.githubusercontent.com/582666/79699911-abf4ba80-8292-11ea-950a-70fc838f42ef.png)

After:
![after](https://user-images.githubusercontent.com/582666/79699916-af884180-8292-11ea-9dd6-db6ebd9089ba.png)


Have a nice day and stay safe.