### PR TITLE
Ignore old push devices

### DIFF
--- a/lib/Push.php
+++ b/lib/Push.php
@@ -293,6 +293,7 @@ class Push {
 			// Token does not exist anymore, should drop the push device entry
 			$this->printInfo('InvalidTokenException is thrown');
 			$this->deletePushToken($tokenId);
+			$this->cache->set('t' . $tokenId, 0, 600);
 			return false;
 		}
 	}


### PR DESCRIPTION
* Don't push to devices that didn't authenticate with in the last 60 days
* Cache the activity timestamp and device existance for 10 mins (if it was revoked, the client getting the details for the notification will fail authentication anyway)