### PR TITLE
Fix wordwrap issue regression from #540, fix #679

### DIFF
--- a/css/styles.scss
+++ b/css/styles.scss
@@ -124,7 +124,7 @@
 		& > span.text,
 		& > a > span.text {
 			padding-left: 10px;
-			line-break: anywhere;
+			word-wrap: anywhere;
 		}
 	}
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/notifications/issues/679 caused by https://github.com/nextcloud/notifications/pull/540, please review @ChristophWurst @nickvergessen @meneer @kesselb 

Note that before, the word "conversation" is cut even though it is a very short word. Afterwards, only the overlong conversation name is cut. (The emoji being on the line before is a drawback, but well, it _is_ a different word.)

Before | After
-|-
![notification before](https://user-images.githubusercontent.com/925062/86367248-fecbf480-bc7b-11ea-8b0a-485a8b5d0fe6.png) | ![Notifications wrap after](https://user-images.githubusercontent.com/925062/86367246-fe335e00-bc7b-11ea-987a-725a1ccc7462.png)

