### PR TITLE
Also check responses of 400 errors and so delete unknown devices

### DIFF
--- a/lib/Push.php
+++ b/lib/Push.php
@@ -320,6 +320,7 @@ class Push {
 
 			if (is_array($bodyData) && isset($bodyData['unknown'], $bodyData['failed'])) {
 				if (is_array($bodyData['unknown'])) {
+					// Proxy returns null when the array is empty
 					foreach ($bodyData['unknown'] as $unknownDevice) {
 						$this->printInfo('Deleting device because it is unknown by the push server: ' . $unknownDevice);
 						$this->deletePushTokenByDeviceIdentifier($unknownDevice);

--- a/lib/Push.php
+++ b/lib/Push.php
@@ -295,7 +295,7 @@ class Push {
 				$body = $response->getBody();
 				$error = \is_string($body) ? $body : ('no reason given (' . $response->getStatusCode() . ')');
 
-				$this->log->debug('Could not send notification to push server [{url}]: {error}',[
+				$this->log->debug('Could not send notification to push server [{url}]: {error}', [
 					'error' => $error,
 					'url' => $proxyServer,
 					'app' => 'notifications',
@@ -318,10 +318,12 @@ class Push {
 			$body = $response->getBody();
 			$bodyData = json_decode($body, true);
 
-			if (is_array($bodyData) && isset($bodyData['unknown'], $bodyData['failed']) && is_array($bodyData['unknown'])) {
-				foreach ($bodyData['unknown'] as $unknownDevice) {
-					$this->printInfo('Deleting device because it is unknown by the push server: ' . $unknownDevice);
-					$this->deletePushTokenByDeviceIdentifier($unknownDevice);
+			if (is_array($bodyData) && isset($bodyData['unknown'], $bodyData['failed'])) {
+				if (is_array($bodyData['unknown'])) {
+					foreach ($bodyData['unknown'] as $unknownDevice) {
+						$this->printInfo('Deleting device because it is unknown by the push server: ' . $unknownDevice);
+						$this->deletePushTokenByDeviceIdentifier($unknownDevice);
+					}
 				}
 
 				if ($bodyData['failed'] !== 0) {


### PR DESCRIPTION
So before this PR, we tried to act on 400 errors already, but I didn't know that they throw an exception on the `post()`, so instead of performing on the response body, we `continue;` after we logged an info … :hushed: 

This is of course not what was intended. Further more, since the notifications are grouped and the proxy had an error which would immediately bail out with a 400 when there was 1 unknown device, instead of sending the rest, 1 broken notification token was enough to not send any notification anymore. And since we never deleted the unknown device the instance didn't "heal" itself, but always broke like this.