### PR TITLE
add event when notifications have been processed

### DIFF
--- a/lib/Event/NotificationProcessed.php
+++ b/lib/Event/NotificationProcessed.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Notification\Event;
+
+use OCP\EventDispatcher\Event;
+use OCP\Notification\INotification;
+
+class NotificationProcessed  extends Event {
+	private $notification;
+
+	public function __construct(INotification $notification) {
+		parent::__construct();
+		$this->notification = $notification;
+	}
+
+	public function getNotification(): INotification {
+		return $this->notification;
+	}
+}


### PR DESCRIPTION
Currently, `notify_push` pretends to be a notifier app and implements the `markProcessed` method to listen to apps marking notifications as processed, however, an app calling `markProcessed` doesn't necessarily mean that there are any notifications that match the filter.

For example, the talk app calls `markProcessed` for a room every time the user sets the read marker.

From what I can tell there is no efficient way for the `notify_push` app to know when a `markProcessed` call actually clears any notifications, however the `notify` app already has this data while it's doing it's mobile push. By having it emit an event we can reuse this work.