### PR TITLE
Fix admin notification api

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -27,6 +27,7 @@ return [
 		['name' => 'Endpoint#deleteAllNotifications', 'url' => '/api/{apiVersion}/notifications', 'verb' => 'DELETE', 'requirements' => ['apiVersion' => 'v(1|2)']],
 		['name' => 'Push#registerDevice', 'url' => '/api/{apiVersion}/push', 'verb' => 'POST', 'requirements' => ['apiVersion' => 'v2']],
 		['name' => 'Push#removeDevice', 'url' => '/api/{apiVersion}/push', 'verb' => 'DELETE', 'requirements' => ['apiVersion' => 'v2']],
-		['name' => 'API#generateNotification', 'url' => '/api/{apiVersion}/notifications/{userId}', 'verb' => 'POST', 'requirements' => ['apiVersion' => 'v(1|2)'], 'root' => '/apps/admin_notifications'],
+
+		['name' => 'API#generateNotification', 'url' => '/api/{apiVersion}/admin_notifications/{userId}', 'verb' => 'POST', 'requirements' => ['apiVersion' => 'v(1|2)']],
 	],
 ];

--- a/docs/admin-notifications.md
+++ b/docs/admin-notifications.md
@@ -28,9 +28,13 @@ Options:
 
 ## HTTP request
 
+> ⚠️ The URL had to be changed when switching from Nextcloud 20 to 21:
+> * 20 and earlier: ocs/v2.php/apps/admin_notifications/api/v1/notifications/{user}
+> * 21 and later: ocs/v2.php/apps/notifications/api/v2/admin_notifications/{user}
+
 ```
 curl -H "OCS-APIREQUEST: true" -X POST \
-  https://admin:admin@localhost/ocs/v2.php/apps/admin_notifications/api/v1/notifications/admin \
+  https://admin:admin@localhost/ocs/v2.php/apps/notifications/api/v1/admin_notifications/admin \
   -d "shortMessage=Short message up to 255 characters" \
   -d "longMessage=Optional: longer message with more details, up to 4000 characters"
 ```

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2017 Joas Schilling <coding@schilljs.com>
  *
@@ -43,14 +46,11 @@ class APIController extends OCSController {
 	/** @var IManager */
 	protected $notificationManager;
 
-	/**
-	 * @param string $appName
-	 * @param IRequest $request
-	 * @param ITimeFactory $timeFactory
-	 * @param IUserManager $userManager
-	 * @param IManager $notificationManager
-	 */
-	public function __construct($appName, IRequest $request, ITimeFactory $timeFactory, IUserManager $userManager, IManager $notificationManager) {
+	public function __construct(string $appName,
+								IRequest $request,
+								ITimeFactory $timeFactory,
+								IUserManager $userManager,
+								IManager $notificationManager) {
 		parent::__construct($appName, $request);
 
 		$this->timeFactory = $timeFactory;

--- a/tests/Integration/features/admin-notification-v2.feature
+++ b/tests/Integration/features/admin-notification-v2.feature
@@ -1,0 +1,27 @@
+Feature: admin-notification
+  Background:
+    Given user "test1" exists
+    Given as user "test1"
+
+  Scenario: Create notification
+    Given user "admin" sends admin notification to "test1" with
+      | shortMessage | without long message |
+    Then user "test1" has 1 notifications on v2
+    And last notification on v2 matches
+      | app | admin_notifications |
+      | subject | without long message |
+      | link | |
+      | message | |
+      | object_type | admin_notifications |
+
+  Scenario: Create different notification
+    Given user "admin" sends admin notification to "test1" with
+      | shortMessage | with long message |
+      | longMessage | this is long message |
+    Then user "test1" has 1 notifications on v2
+    And last notification on v2 matches
+      | app | admin_notifications |
+      | subject | with long message |
+      | link | |
+      | message | this is long message |
+      | object_type | admin_notifications |

--- a/tests/Integration/features/bootstrap/FeatureContext.php
+++ b/tests/Integration/features/bootstrap/FeatureContext.php
@@ -90,6 +90,21 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	}
 
 	/**
+	 * @Given /^user "([^"]*)" sends admin notification to "([^"]*)" with$/
+	 *
+	 * @param string $sender
+	 * @param string $recipient
+	 * @param TableNode|null $formData
+	 */
+	public function sendAdminNotification(string $sender, string $recipient, TableNode $formData) {
+		$currentUser = $this->currentUser;
+		$this->setCurrentUser($sender);
+		$this->sendingToWith('POST', '/apps/notifications/api/v2/admin_notifications/' . $recipient . '?format=json', $formData);
+		$this->assertStatusCode($this->response, 200);
+		$this->setCurrentUser($currentUser);
+	}
+
+	/**
 	 * @When /^getting notifications on (v\d+)(| with different etag| with matching etag)$/
 	 * @param string $api
 	 * @param string $eTag


### PR DESCRIPTION
Fix #877 

The app/route loading in 21 changed, so notifications app can not define a route for admin_notifications anymore 😿  So we need to migrate the route into the notifications name space.
I thought this is tested but it was not, so now it has an integration test added