### PR TITLE
Fix handling the response of the proxy

### DIFF
--- a/lib/Push.php
+++ b/lib/Push.php
@@ -307,7 +307,7 @@ class Push {
 			} catch (ServerException $e) {
 				// Server responded with 5xx
 				$response = $e->getResponse();
-				$body = $response->getBody();
+				$body = $response->getBody()->getContents();
 				$error = \is_string($body) ? $body : ('no reason given (' . $response->getStatusCode() . ')');
 
 				$this->log->debug('Could not send notification to push server [{url}]: {error}', [
@@ -329,7 +329,7 @@ class Push {
 			}
 
 			$status = $response->getStatusCode();
-			$body = $response->getBody();
+			$body = $response->getBody()->getContents();
 			$bodyData = json_decode($body, true);
 
 			if (is_array($bodyData) && array_key_exists('unknown', $bodyData) && array_key_exists('failed', $bodyData)) {
@@ -347,7 +347,7 @@ class Push {
 					$this->printInfo('Push notification sent successfully');
 				}
 			} elseif ($status !== Http::STATUS_OK) {
-				$error = \is_string($body) && $body && $bodyData === null ? $body : 'no reason given';
+				$error = $body && $bodyData === null ? $body : 'no reason given';
 				$this->printInfo('Could not send notification to push server [' . $proxyServer . ']: ' . $error);
 				$this->log->warning('Could not send notification to push server [{url}]: {error}', [
 					'error' => $error,
@@ -355,7 +355,7 @@ class Push {
 					'app' => 'notifications',
 				]);
 			} else {
-				$error = \is_string($body) && $body && $bodyData === null ? $body : 'no reason given';
+				$error = $body && $bodyData === null ? $body : 'no reason given';
 				$this->printInfo('Push notification sent but response was not parsable, using an outdated push proxy? [' . $proxyServer . ']: ' . $error);
 				$this->log->info('Push notification sent but response was not parsable, using an outdated push proxy? [{url}]: {error}', [
 					'error' => $error,

--- a/tests/Unit/PushTest.php
+++ b/tests/Unit/PushTest.php
@@ -45,6 +45,7 @@ use OCP\Notification\INotification;
 use OCP\UserStatus\IManager as IUserStatusManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -524,9 +525,14 @@ class PushTest extends TestCase {
 		$response1->expects($this->once())
 			->method('getStatusCode')
 			->willReturn(Http::STATUS_BAD_REQUEST);
+		/** @var StreamInterface|MockObject $body1 */
+		$body1 = $this->createMock(StreamInterface::class);
+		$body1->expects($this->once())
+			->method('getContents')
+			->willReturn('');
 		$response1->expects($this->once())
 			->method('getBody')
-			->willReturn('');
+			->willReturn($body1);
 		$e = $this->createMock(ClientException::class);
 		$e->method('getResponse')
 			->willReturn($response1);
@@ -549,9 +555,14 @@ class PushTest extends TestCase {
 
 		/** @var ResponseInterface|MockObject $response1 */
 		$response2 = $this->createMock(ResponseInterface::class);
+		/** @var StreamInterface|MockObject $body2 */
+		$body2 = $this->createMock(StreamInterface::class);
+		$body2->expects($this->once())
+			->method('getContents')
+			->willReturn('Maintenance');
 		$response2->expects($this->once())
 			->method('getBody')
-			->willReturn('Maintenance');
+			->willReturn($body2);
 		$e = $this->createMock(ServerException::class);
 		$e->method('getResponse')
 			->willReturn($response2);
@@ -577,8 +588,13 @@ class PushTest extends TestCase {
 		$response3->expects($this->once())
 			->method('getStatusCode')
 			->willReturn(Http::STATUS_OK);
-		$response3->method('getBody')
+		/** @var StreamInterface|MockObject $body3 */
+		$body3 = $this->createMock(StreamInterface::class);
+		$body3->expects($this->once())
+			->method('getContents')
 			->willReturn('');
+		$response3->method('getBody')
+			->willReturn($body3);
 		$client->expects($this->at(3))
 			->method('post')
 			->with('ok/notifications', [
@@ -593,14 +609,19 @@ class PushTest extends TestCase {
 		$response4->expects($this->once())
 			->method('getStatusCode')
 			->willReturn(Http::STATUS_BAD_REQUEST);
-		$response4->expects($this->once())
-			->method('getBody')
+		/** @var StreamInterface|MockObject $body4 */
+		$body4 = $this->createMock(StreamInterface::class);
+		$body4->expects($this->once())
+			->method('getContents')
 			->willReturn(json_encode([
 				'failed' => 1,
 				'unknown' => [
 					'123456'
 				]
 			]));
+		$response4->expects($this->once())
+			->method('getBody')
+			->willReturn($body4);
 		$e = $this->createMock(ClientException::class);
 		$e->method('getResponse')
 			->willReturn($response4);
@@ -726,9 +747,14 @@ class PushTest extends TestCase {
 			$response->expects($this->once())
 				->method('getStatusCode')
 				->willReturn(Http::STATUS_BAD_REQUEST);
+			/** @var StreamInterface|MockObject $body */
+			$body = $this->createMock(StreamInterface::class);
+			$body->expects($this->once())
+				->method('getContents')
+				->willReturn('');
 			$response->expects($this->once())
 				->method('getBody')
-				->willReturn('');
+				->willReturn($body);
 			$client->expects($this->once())
 				->method('post')
 				->with('proxyserver/notifications', [


### PR DESCRIPTION
```
      "Exception": "TypeError",
      "Message": "json_decode() expects parameter 1 to be string, object given",
      "Code": 0,
      "Trace": [
        {
          "file": "/var/www/html/apps/notifications/lib/Push.php",
          "line": 333,
          "function": "json_decode"
        },
        {
          "file": "/var/www/html/apps/notifications/lib/Push.php",
          "line": 124,
          "function": "sendNotificationsToProxies",
          "class": "OCA\\Notifications\\Push",
          "type": "->"
        },
        {
          "file": "/var/www/html/apps/notifications/lib/App.php",
          "line": 99,
          "function": "flushPayloads",
          "class": "OCA\\Notifications\\Push",
          "type": "->"
        },
```