### PR TITLE
High priority for the PhoneTrack app

### DIFF
--- a/lib/Push.php
+++ b/lib/Push.php
@@ -422,6 +422,9 @@ class Push {
 		} elseif ($data['app'] === 'twofactor_nextcloud_notification') {
 			$priority = 'high';
 			$type = 'alert';
+		} elseif ($data['app'] === 'phonetrack') {
+			$priority = 'high';
+			$type = 'alert';
 		} else {
 			$priority = 'normal';
 			$type = 'alert';


### PR DESCRIPTION
Added high priority for notifications for PhoneTrack. Notifications sent from this application are also important for users. The information it contains must be received very quickly in the event of exceeding the set zone or approaching two devices.

Signed-off-by: Valdnet <47037905+Valdnet@users.noreply.github.com>