### PR TITLE
Restore old device signature so the proxy works again

### DIFF
--- a/lib/Controller/PushController.php
+++ b/lib/Controller/PushController.php
@@ -118,8 +118,13 @@ class PushController extends OCSController {
 		$key = $this->identityProof->getKey($user);
 
 		$deviceIdentifier = json_encode([$user->getCloudId(), $token->getId()]);
-		$deviceIdentifier = base64_encode(hash('sha512', $deviceIdentifier, true));
 		openssl_sign($deviceIdentifier, $signature, $key->getPrivate(), OPENSSL_ALGO_SHA512);
+		/**
+		 * For some reason the push proxy's golang code needs the signature
+		 * of the deviceIdentifier before the sha512 hashing. Assumption is that
+		 * openssl_sign already does the sha512 internally.
+		 */
+		$deviceIdentifier = base64_encode(hash('sha512', $deviceIdentifier, true));
 
 		$appType = 'unknown';
 		if ($this->request->isUserAgent([

--- a/tests/Integration/features/push-registration.feature
+++ b/tests/Integration/features/push-registration.feature
@@ -38,7 +38,7 @@ Feature: Push registration
     | devicePublicKey | VALID_KEY |
     | proxyServer | https://push-notifications.nextcloud.com/ |
     Then status code is 201
-    And can validate the response and signature
+    And can validate the response and skip verifying signature
 
   Scenario: Unregistering from push notifications without app password
     Given user "test1" forgets the app password
@@ -52,7 +52,7 @@ Feature: Push registration
       | devicePublicKey | VALID_KEY |
       | proxyServer | https://push-notifications.nextcloud.com/ |
     Then status code is 201
-    And can validate the response and signature
+    And can validate the response and skip verifying signature
     Given user "test1" unregisters from push notifications
     Then status code is 202
     Given user "test1" unregisters from push notifications

--- a/tests/Unit/Controller/PushControllerTest.php
+++ b/tests/Unit/Controller/PushControllerTest.php
@@ -302,7 +302,7 @@ FwIDAQAB
 				[
 					'publicKey' => $this->userPublicKey,
 					'deviceIdentifier' => 'XUCEZ1EHvTUcVhIvrQQQ1XcP0ZD2BFdFqw4EYbOhBfiEgXgirurR4x/ve4GSSyfivvbQOdOkZUM+g4m+tSb0Ew==',
-					'signature' => 'X9+J7NNLfG9Ft6C36zrYLVJ5aH5euIROzdV937hsU81jL7WvOwzBfc7bImzxU3Bnev5wEKwkw7Ts/2q/+UUkOxgtEZinp52s87S5obKtsVXsczHbsqg4p/ueoBPhF17VsP1e8kMtxZ4snk/iArX4Eu1cfaM3+OckmpO0MYXy0rUbYpQPAJo4VgRFKKjFvfEVOj8N74DTIJ+TjRsvvDhJbb9KpeFe3a6Rv9mIo0AqoK+deAbUkWY0aM+74noVXvPtNzExgK4mWJ02+JHEuQEUbCuQsgoBia0vC3fILbwVxHzrieWGEnE7vkRyFEzlkeo7ZSMawDPxsPN5HxwBs2SZig==',
+					'signature' => 'LRhbXO71WYX9qqDbQX7C+87YaaFfWoT/vG0DlaXdBz6+lhyOA0dw/1Ggz3fd7RerCQ0MfgnnTyxO+cSeRpUaPdA2yPjfoiPpfYA5SOJQGF3comS/HYna3fHiFDbOoM3BJOnjvqiSZdxA/ICdyl2mEEC5wO7AZ4OZKBTa5XfL7eSCXZLEv1YldqcLOStbXrI7voDQocTMJxoQZI/j8BVcf2i3D6F454aXIFDrYYzC2PQY+CKJoXZW0m0RMWaTM2B8tBmFFwrmaGLDqcjjpd33TsTtsV5DB7WimffLBPpOuGV4Z1Kiagp/mxpPLz2NImNV79mDX9gY3ZppCZTwChP5qQ==',
 				],
 				Http::STATUS_CREATED,
 			],
@@ -317,7 +317,7 @@ FwIDAQAB
 				[
 					'publicKey' => $this->userPublicKey,
 					'deviceIdentifier' => 'x9vSImcGjhzR9BfZ/XbbUqqCCNC4bHKsX7vkQWNZRd1/MiY+OuF02fx8K08My0RpkNnwj/rQ/gVSU1oEdFwkww==',
-					'signature' => 'GFpnv3MO7mcBef2RJ4Ayrl6RQakGM7AvlKhoTr3DUWnv+iBzwGy8YV34HIPoArz4tyqonHRlLsxPYq4ENPfGO99KrIS16z4RUq0wiCBGf+S8/K8lM9cE9EBKE9yrkTsSvZGICEusvxQ+cTfVr30bnavvi1wL1UuxxDBlJebda9FJ9HfaS24j4rT7K78oMguqDVM+4hhr6BMhcpUVV+kTpOaBpluw5pRDwUP3jJBmkkOa57WRKFcu0Lr/XIx/G0c8Si+BAfM//CTMstwp5XDFn4W9EYSStjNrvsULdV+tOKFwnowqts+UFzEDvmZ1g4qIMWUUPBF4/pjaiDqtMojgrA==',
+					'signature' => 'J9AcdJt5youJmMnBhS+Cc9ytArynIKtCRoNf/m0oOFO/e0hWHqs1NRdQBe81qzYIjf0+bj0Q97X9Xv1rnVJesPkQUbGaa4nAPt+viGSfvzTptjX4LKgqm8B3UkduBA262IcaWgM5P84gUqelkQIC1nIqq/MJTuC6oQ5lUwIV1a92ZurDjhwH4b3f7/ZLTTOTRD0DWN9W/yOyF1qECivgePR3eu+mkcBzXVU/TDZDJic9G7xhqcTnWV6qk+aKyzdNo1tu5W7mF+v5vF6rrGZrq55vPLWAHApTD7P+NFV01BnaCuN7/qGJNVs7m7EH03jpOw7y3jqNMmcmonYrJSMVqg==',
 				],
 				Http::STATUS_OK,
 			],


### PR DESCRIPTION
Reverting #1081 

cc @bytepoets-mzi Not sure what's wrong with golang vs. php, but I have to revert this so push notifications work again for our devices.

Verification test on https://play.golang.org/ prints:
```
OK HashAfterSign
Invalid signature HashBeforeSign

Program exited.
```

Sample go code:
```go
// You can edit this code!
// Click here and start typing.
package main

import (
	"crypto"
	"crypto/rsa"
	"crypto/x509"
	"encoding/base64"
	"encoding/pem"
	"fmt"
)

func main() {
	userPublicKey := `-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwc4lFZz05CtWnRVIKkOz
vSZYfVZpD23K/7YVsoMZXsh7hrzJTFV6dmrJS01yTecF3I/tgL3Kt5kEyL2bRJpy
DUWRuqTWnqTnpbL6yTsMqeC/+eVPH3boCj6xEBEM2NQrNjUDnm2BFZszGyEHJj0B
LeBmOxBE1e7V4jBQGCrhoW9bLL1Oc434q7+pIFCSBT5a/ZQefqRrRWb68KjA9Xzq
1RA4z1MCBgejeC/k14Pg/xsr8Ixjw2SxOaFGcszInQemTvAeHplwlwmebKpW3Q0l
QAbwSfPUGX9TAUsOyhbazinEUpUXMmobHQM3matTRjcwYVbRpRSbG3XIxSsrfF2a
UwIDAQAB
-----END PUBLIC KEY-----`

	block, _ := pem.Decode([]byte(userPublicKey))
	if block == nil {
		fmt.Println("Invalid public key")
	}

	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
	if err != nil || pub == nil {
		fmt.Println("Invalid public key")
	}

	publicKey, ok := pub.(*rsa.PublicKey)
	if !ok {
		fmt.Println("Invalid public key")
	}

	deviceIdentifierHashAfterSign := "JIFqiMjfu5uzeTqa2k++BimoukxtOwOAQjIT8MAZ8/5rbhXq085eXkUnaoJJWFTJ8u7jBVEWkIcuJYot1mhQUw=="
	deviceIdentifierSignatureHashAfterSign := "vYo3lnXW+fVjtI2+XRxWIidKY0iW6OLxcipe5ThuqGdfsXhJQhQHWuR7IUEmiLgPtiobHStFIVaddXfDhgZnDRLe//kKBRsPzfqRI1dS9Q0C+38DRz/loNMp/WXYs0Ug4CSkG5otVnbqtYErCluZ3gA/hhBAzRi+Jw4lGkECEVdpt5XEvAi0A/bF7KK04JUkSHcJGpuGtxUzqUhSpNRRVCyN8LY10Q59whwfd0zlEqgGq3Wv+7tFaoZsD7iQ7jWFmbtzF3Z4QV7E7zH33BFX8Bdzu3NdWfDmkBBaB0K6HESObkTv5+sX/Z6UJ1ETYdQed6H7E/FLTl5UN4CqCWEHPA=="

	rawDeviceIdentifierHashHashAfterSign, err := base64.StdEncoding.DecodeString(deviceIdentifierHashAfterSign)
	if err != nil {
		fmt.Println("Invalid input HashAfterSign")
	}

	signatureHashAfterSign, err := base64.StdEncoding.DecodeString(deviceIdentifierSignatureHashAfterSign)
	if err != nil {
		fmt.Println("Invalid signature data HashAfterSign")
	}

	if err = rsa.VerifyPKCS1v15(publicKey, crypto.SHA512, rawDeviceIdentifierHashHashAfterSign, signatureHashAfterSign); err != nil {
		fmt.Println("Invalid signature HashAfterSign")
	} else {
		fmt.Println("OK HashAfterSign")
	}
	
	deviceIdentifierHashBeforeSign := "396hZP/Ww13/fbg/7xyLHn789ZBfMBEnhX7gQBub7iWY0LhcPzOin28zM+bLwNSRNOOCbsspBEu1eZB61+rieA=="
	deviceIdentifierSignatureHashBeforeSign := "aZsxhwzLOFVigIp7SfOgxghIVu2sgCbipqmxwgEn2QBH0PA8/j0738MI90JtEe2Fv6mrg4Sjo7/CmCZlo/KCya6JahFtK4zy07CbLS7hX7y1ACBkJJ8CWfhxm/UHtwzG+DVN5UrelHYcTnq6+gGFAlZEKs2ehD3QEqGxHZuJKR8WsUYFIbdrcfqwpEjqT85jyr615+hBWDQuToQQa/xPzw2jotHPP7r5I2dTEwbxdHpThFA5Av9NT0RExLYaphti+lInN25JxqlWDIbVg4pHko3G0LS+ca4Eu1tV1NPwkilTVzAYYPpEi7tfYodbgoMzv/bs0gMpgA7E+pjz1sToAQ=="

	rawDeviceIdentifierHashHashBeforeSign, err := base64.StdEncoding.DecodeString(deviceIdentifierHashBeforeSign)
	if err != nil {
		fmt.Println("Invalid input HashBeforeSign")
	}

	signatureHashBeforeSign, err := base64.StdEncoding.DecodeString(deviceIdentifierSignatureHashBeforeSign)
	if err != nil {
		fmt.Println("Invalid signature data HashBeforeSign")
	}

	if err = rsa.VerifyPKCS1v15(publicKey, crypto.SHA512, rawDeviceIdentifierHashHashBeforeSign, signatureHashBeforeSign); err != nil {
		fmt.Println("Invalid signature HashBeforeSign")
	} else {
		fmt.Println("OK HashBeforeSign")
	}
}
```

