### PR TITLE
Improve feedback in test-push when device is too old

### DIFF
--- a/lib/Push.php
+++ b/lib/Push.php
@@ -170,7 +170,7 @@ class Push {
 		if (isset($userStatus[$notification->getUser()])) {
 			$userStatus = $userStatus[$notification->getUser()];
 			if ($userStatus->getStatus() === IUserStatus::DND) {
-				$this->printInfo('User status is set to DND');
+				$this->printInfo('<error>User status is set to DND - no push notifications will be sent</error>');
 				return;
 			}
 		}
@@ -390,6 +390,11 @@ class Push {
 			// Check if the token is still valid...
 			$token = $this->tokenProvider->getTokenById($tokenId);
 			$this->cache->set('t' . $tokenId, $token->getLastCheck(), 600);
+			if ($token->getLastCheck() > $maxAge) {
+				$this->printInfo('Device token is valid');
+			} else {
+				$this->printInfo('Device token "last checked" is older than 60 days: ' . $token->getLastCheck());
+			}
 			return $token->getLastCheck() > $maxAge;
 		} catch (InvalidTokenException $e) {
 			// Token does not exist anymore, should drop the push device entry


### PR DESCRIPTION
Before
```
$ occ notification:test-push … --talk
Trying to push to 1 devices

Language is set to de_DE
Private user key size: 1704
Public user key size: 451
Identified 1 Talk devices and 0 others.

Device token:98908
$
```
there is no further message and you wonder what the issue is.


After
```
$ occ notification:test-push … --talk
Trying to push to 1 devices

Language is set to de_DE
Private user key size: 1704
Public user key size: 451
Identified 1 Talk devices and 0 others.

Device token:98908
Device token "last checked" is older than 60 days: 1601185625
$
```