### PR TITLE
Improve mass notification processing

### DIFF
--- a/lib/App.php
+++ b/lib/App.php
@@ -54,8 +54,7 @@ class App implements IDeferrableApp {
 		$notificationId = $this->handler->add($notification);
 
 		try {
-			$notificationToPush = $this->handler->getById($notificationId, $notification->getUser());
-			$this->push->pushToDevice($notificationId, $notificationToPush);
+			$this->push->pushToDevice($notificationId, $notification);
 		} catch (NotificationNotFoundException $e) {
 			throw new \InvalidArgumentException('Error while preparing push notification');
 		}

--- a/tests/Unit/AppTest.php
+++ b/tests/Unit/AppTest.php
@@ -53,8 +53,8 @@ class AppTest extends TestCase {
 
 	public function dataNotify() {
 		return [
-			[23, 'user1'],
-			[42, 'user2'],
+			[23],
+			[42],
 		];
 	}
 
@@ -62,21 +62,12 @@ class AppTest extends TestCase {
 	 * @dataProvider dataNotify
 	 *
 	 * @param int $id
-	 * @param string $user
 	 */
-	public function testNotify($id, $user) {
-		$this->notification->expects($this->once())
-			->method('getUser')
-			->willReturn($user);
-
+	public function testNotify($id) {
 		$this->handler->expects($this->once())
 			->method('add')
 			->with($this->notification)
 			->willReturn($id);
-		$this->handler->expects($this->once())
-			->method('getById')
-			->with($id, $user)
-			->willReturn($this->notification);
 		$this->push->expects($this->once())
 			->method('pushToDevice')
 			->with($id, $this->notification);


### PR DESCRIPTION
### Steps
1. Create 70 users:
```sh
i=10
while [ $i -ne 70 ]
do
        i=$(($i+1))
        echo "$i"

	USERID=$(uuidgen)
	OC_PASS="123456" occ -vvv user:add --password-from-env --display-name "Dummy #$i" -g "dummies" $USERID
	occ -vvv user:setting $USERID settings email "test$i@yourdomain.tld"

done
```
2. Create a conversation as admin with group "dummies"
3. Start a call
4. Measure time around the section in talk:
https://github.com/nextcloud/spreed/blob/1aaf10e2653e764ed54a6abc9eac750753263a3c/lib/Notification/Listener.php#L234-L253
```php
			// Add this after https://github.com/nextcloud/spreed/blob/1aaf10e2653e764ed54a6abc9eac750753263a3c/lib/Notification/Listener.php#L233
			$start = microtime(true);
```
```php
			// Add this before https://github.com/nextcloud/spreed/blob/1aaf10e2653e764ed54a6abc9eac750753263a3c/lib/Notification/Listener.php#L255
			$end = microtime(true);
			\OC::$server->getLogger()->error('notify: ' . ($end - $start));
```
5. Measure the patch again with the beginTransaction and commit being commented out

With patch | Without patch
---|---
~0.01s | ~0.5s
