### PR TITLE
Use a fake user to skip database queries

### DIFF
--- a/lib/FakeUser.php
+++ b/lib/FakeUser.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Notifications;
+
+use OCP\IUser;
+
+class FakeUser implements IUser {
+	protected string $userId;
+
+	public function __construct(string $userId) {
+		$this->userId = $userId;
+	}
+
+	public function getUID(): string {
+		return $this->userId;
+	}
+
+	public function getCloudId() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function getSystemEMailAddress(): ?string {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function getPrimaryEMailAddress(): ?string {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function getDisplayName() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function setDisplayName($displayName) {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function getLastLogin() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function updateLastLoginTimestamp() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function delete() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function setPassword($password, $recoveryPassword = null) {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function getHome() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function getBackendClassName() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function getBackend() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function canChangeAvatar() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function canChangePassword() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function canChangeDisplayName() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function isEnabled() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function setEnabled(bool $enabled = true) {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function getEMailAddress() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function getAvatarImage($size) {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function setEMailAddress($mailAddress) {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function getQuota() {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function setQuota($quota) {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function setSystemEMailAddress(string $mailAddress): void {
+		throw new \RuntimeException('Not implemented');
+	}
+
+	public function setPrimaryEMailAddress(string $mailAddress): void {
+		throw new \RuntimeException('Not implemented');
+	}
+}

--- a/lib/Push.php
+++ b/lib/Push.php
@@ -38,7 +38,6 @@ use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUser;
-use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
@@ -59,8 +58,6 @@ class Push {
 	protected $tokenProvider;
 	/** @var Manager */
 	private $keyManager;
-	/** @var IUserManager */
-	private $userManager;
 	/** @var IClientService */
 	protected $clientService;
 	/** @var ICache */
@@ -83,7 +80,6 @@ class Push {
 								IConfig $config,
 								IProvider $tokenProvider,
 								Manager $keyManager,
-								IUserManager $userManager,
 								IClientService $clientService,
 								ICacheFactory $cacheFactory,
 								IUserStatusManager $userStatusManager,
@@ -94,7 +90,6 @@ class Push {
 		$this->config = $config;
 		$this->tokenProvider = $tokenProvider;
 		$this->keyManager = $keyManager;
-		$this->userManager = $userManager;
 		$this->clientService = $clientService;
 		$this->cache = $cacheFactory->createDistributed('pushtokens');
 		$this->userStatusManager = $userStatusManager;
@@ -159,10 +154,7 @@ class Push {
 			return;
 		}
 
-		$user = $this->userManager->get($notification->getUser());
-		if (!($user instanceof IUser)) {
-			return;
-		}
+		$user = $this->createFakeUserObject($notification->getUser());
 
 		$userStatus = $this->userStatusManager->getUserStatuses([
 			$notification->getUser(),
@@ -245,10 +237,7 @@ class Push {
 			return;
 		}
 
-		$user = $this->userManager->get($userId);
-		if (!($user instanceof IUser)) {
-			return;
-		}
+		$user = $this->createFakeUserObject($userId);
 
 		$devices = $this->getDevicesForUser($userId);
 		if ($notificationId !== 0 && $app !== '') {
@@ -549,5 +538,9 @@ class Push {
 			->where($query->expr()->eq('deviceidentifier', $query->createNamedParameter($deviceIdentifier)));
 
 		return $query->executeStatement() !== 0;
+	}
+
+	protected function createFakeUserObject(string $userId): IUser {
+		return new FakeUser($userId);
 	}
 }


### PR DESCRIPTION
Getting a user runs 2 queries:
1. Load the user from oc_users or any other database backend
2. Load the preferences: https://github.com/nextcloud/server/pull/31363

This is somewhat dangerous, but all methods only rely on the
userId and the objects are not cached anywhere on the way,
so this should still work and does in tests

### Query log from starting a call with 70 users in a room
![Bildschirmfoto von 2022-02-25 22-55-44](https://user-images.githubusercontent.com/213943/155809020-c60d00bb-084f-4c9c-a195-386a7cc53f53.png)

