### PR TITLE
Enable helper app with force

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,6 +76,9 @@ jobs:
         working-directory: apps/${{ env.APP_NAME }}/tests/Integration
         run: bash run.sh
 
+      - name: Print query.log
+        run: cat /home/runner/work/notifications/notifications/query.log
+
       - name: Query count
         uses: actions/github-script@v5
         with:

--- a/tests/Integration/run.sh
+++ b/tests/Integration/run.sh
@@ -12,7 +12,7 @@ composer install
 
 cp -R ./app ../../../notificationsintegrationtesting
 ${ROOT_DIR}/occ app:enable notifications
-${ROOT_DIR}/occ app:enable notificationsintegrationtesting
+${ROOT_DIR}/occ app:enable --force notificationsintegrationtesting
 ${ROOT_DIR}/occ app:enable provisioning_api
 ${ROOT_DIR}/occ app:list | grep notifications
 ${ROOT_DIR}/occ app:list | grep provisioning_api


### PR DESCRIPTION
This allows to not bump the version in the helper app anymore.
Will save me a roundtrip of CI every time we branch off as I always forget it.

Similar to https://github.com/nextcloud/spreed/pull/7218