### PR TITLE
Handle notification params replacement being null

### DIFF
--- a/lib/MailNotifications.php
+++ b/lib/MailNotifications.php
@@ -366,6 +366,10 @@ class MailNotifications {
 				$replacement = $parameter['name'];
 			}
 
+			if (!$replacement) {
+				continue;
+			}
+
 			if (isset($parameter['link'])) {
 				$replacements[] = '<a href="' . $parameter['link'] . '">' . htmlspecialchars($replacement) . '</a>';
 			} else {


### PR DESCRIPTION
Unclear how & why this happens, but at least now it's handled.

```
TypeError: htmlspecialchars() expects parameter 1 to be string, null given in /var/www/nextcloud/apps/notifications/lib/MailNotifications.php:372
Stack trace:
#0 /var/www/nextcloud/apps/notifications/lib/MailNotifications.php(372): htmlspecialchars(NULL)
#1 /var/www/nextcloud/apps/notifications/lib/MailNotifications.php(333): OCA\Notifications\MailNotifications->replaceRichParameters(Array, '{actor} a mis \xC3...')
#2 /var/www/nextcloud/apps/notifications/lib/MailNotifications.php(312): OCA\Notifications\MailNotifications->getHTMLSubject(Object(OC\Notification\Notification))
#3 /var/www/nextcloud/apps/notifications/lib/MailNotifications.php(278): OCA\Notifications\MailNotifications->getHTMLContents(Object(OC\Notification\Notification))
#4 /var/www/nextcloud/apps/notifications/lib/MailNotifications.php(211): OCA\Notifications\MailNotifications->prepareEmailMessage('<uid>', Array, 'fr', 'Europe/Paris')
#5 /var/www/nextcloud/apps/notifications/lib/MailNotifications.php(166): OCA\Notifications\MailNotifications->sendEmailToUser(Object(OCA\Notifications\Model\Settings), Array, 'fr', 'Europe/Paris')
#6 /var/www/nextcloud/apps/notifications/lib/BackgroundJob/SendNotificationMails.php(49): OCA\Notifications\MailNotifications->sendEmails(500, 1653305410)
#7 /var/www/nextcloud/lib/public/BackgroundJob/Job.php(79): OCA\Notifications\BackgroundJob\SendNotificationMails->run(NULL)
#8 /var/www/nextcloud/lib/public/BackgroundJob/TimedJob.php(95): OCP\BackgroundJob\Job->execute(Object(OC\BackgroundJob\JobList), Object(OC\Log))
#9 /var/www/nextcloud/cron.php(150): OCP\BackgroundJob\TimedJob->execute(Object(OC\BackgroundJob\JobList), Object(OC\Log))
#10 {main}
```