### PR TITLE
Fix background email job for disabled users

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 
 📣 Announcement center: An announcement was posted by an admin]]></description>
 
-	<version>2.13.0</version>
+	<version>2.13.1</version>
 	<licence>agpl</licence>
 	<author>Joas Schilling</author>
 

--- a/lib/MailNotifications.php
+++ b/lib/MailNotifications.php
@@ -144,10 +144,12 @@ class MailNotifications {
 		foreach ($userSettings as $settings) {
 			if (isset($userEnabled[$settings->getUserId()]) && $userEnabled[$settings->getUserId()] === 'false') {
 				// User is disabled, skip sending the email for them
-				$settings->setNextSendTime(
-					$settings->getNextSendTime() + $settings->getBatchTime()
-				);
-				$this->settingsMapper->update($settings);
+				if ($settings->getNextSendTime() <= $sendTime) {
+					$settings->setNextSendTime(
+						$sendTime + $settings->getBatchTime()
+					);
+					$this->settingsMapper->update($settings);
+				}
 				continue;
 			}
 

--- a/lib/Migration/Version2011Date20220826074907.php
+++ b/lib/Migration/Version2011Date20220826074907.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Joas Schilling <coding@schilljs.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Notifications\Migration;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version2011Date20220826074907 extends SimpleMigrationStep {
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		$query = $this->connection->getQueryBuilder();
+
+		// The maximum valid value is NOW + 7 days, but since updating is fixed
+		// and you only run into the bug at the year 2038, we can also count up 8 days.
+		$time = time() + 3600 * 24 * 8;
+
+		$query->update('notifications_settings')
+			->set('next_send_time', $query->createNamedParameter(1, IQueryBuilder::PARAM_INT))
+			->where($query->expr()->gt('next_send_time', $query->createNamedParameter($time, IQueryBuilder::PARAM_INT)));
+		$count = $query->executeStatement();
+
+		if ($count > 0) {
+			$output->info('Fixed next send of ' . $count . ' disabled users');
+		}
+	}
+}


### PR DESCRIPTION
Before the timestamp was increased with every run for disabled users, so in our database we had an entry with next send time set to `2147477417` which is `Tue Jan 19 2038 01:30:17 GMT+0000` and fails to increase further resulting in:
> Numeric value out of range: 1264 Out of range value for column 'next_send_time' at row

But we should only increase the disabled users when the send time was triggered, like we do for normal users. So here is the fix and a migration to decrease the send time for users that have the value already too far in the future.

Fix #1254 