### PR TITLE
Add option for a dummy test notification

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: phpunit-sqlite-${{ github.head_ref || github.run_id }}

--- a/lib/Notifier/AdminNotifications.php
+++ b/lib/Notifier/AdminNotifications.php
@@ -26,9 +26,14 @@ declare(strict_types=1);
 
 namespace OCA\Notifications\Notifier;
 
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Notification\AlreadyProcessedException;
+use OCP\Notification\IAction;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 
@@ -39,11 +44,19 @@ class AdminNotifications implements INotifier {
 
 	/** @var IURLGenerator */
 	protected $urlGenerator;
+	/** @var IUserManager */
+	protected $userManager;
+	/** @var IRootFolder */
+	protected $rootFolder;
 
 	public function __construct(IFactory $l10nFactory,
-								IURLGenerator $urlGenerator) {
+								IURLGenerator $urlGenerator,
+								IUserManager $userManager,
+								IRootFolder $rootFolder) {
 		$this->l10nFactory = $l10nFactory;
 		$this->urlGenerator = $urlGenerator;
+		$this->userManager = $userManager;
+		$this->rootFolder = $rootFolder;
 	}
 
 	/**
@@ -57,7 +70,7 @@ class AdminNotifications implements INotifier {
 	}
 
 	/**
-	 * Human readable name describing the notifier
+	 * Human-readable name describing the notifier
 	 *
 	 * @return string
 	 * @since 17.0.0
@@ -79,6 +92,117 @@ class AdminNotifications implements INotifier {
 		}
 
 		switch ($notification->getSubject()) {
+			case 'dummy':
+				$subjectParams = $notification->getSubjectParameters();
+				$numActions = (int) $subjectParams[0];
+
+				$user = $this->userManager->get($notification->getUser());
+				assert($user instanceof IUser);
+				$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+				$dirList = $userFolder->getDirectoryListing();
+				if (empty($dirList)) {
+					$file1 = $userFolder;
+				} else {
+					$file1 = array_pop($dirList);
+				}
+				if (empty($dirList)) {
+					$file2 = $userFolder;
+				} else {
+					$file2 = array_shift($dirList);
+					if ($file2 instanceof Folder) {
+						$dirList = $file2->getDirectoryListing();
+						if (!empty($dirList)) {
+							$file2 = array_shift($dirList);
+						}
+					}
+				}
+
+				$path1 = rtrim($file1->getPath(), '/');
+				if (strpos($path1, '/' . $notification->getUser() . '/files/') === 0) {
+					// Remove /user/files/...
+					[,,, $path1] = explode('/', $path1, 4);
+				}
+				$path2 = rtrim($file2->getPath(), '/');
+				if (strpos($path2, '/' . $notification->getUser() . '/files/') === 0) {
+					// Remove /user/files/...
+					[,,, $path2] = explode('/', $path2, 4);
+				}
+
+				$loremIpsum = 'User {actor} owns a file {item}';
+				$loremIpsumLong = 'Lorem {user-2} dolor sit {file-3}, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.' . "\n" . 'Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.';
+
+				$notification->setRichSubject($loremIpsum, [
+					'actor' => [
+						'type' => 'user',
+						'id' => $user->getUID(),
+						'name' => $user->getDisplayName(),
+					],
+					'item' => [
+						'type' => 'file',
+						'id' => $file1->getId(),
+						'name' => $file1->getName(),
+						'size' => $file1->getSize(),
+						'path' => $path1,
+						'link' => $this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $file1->getId()]),
+						'mimetype' => $file1->getMimetype(),
+					],
+				]);
+				$notification->setRichMessage($loremIpsumLong, [
+					'user-2' => [
+						'type' => 'user',
+						'id' => $user->getUID(),
+						'name' => $user->getDisplayName(),
+					],
+					'file-3' => [
+						'type' => 'file',
+						'id' => $file2->getId(),
+						'name' => $file2->getName(),
+						'size' => $file2->getSize(),
+						'path' => $path2,
+						'link' => $this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $file2->getId()]),
+						'mimetype' => $file2->getMimetype(),
+					],
+				]);
+
+				$primary = $notification->createAction();
+				$primary->setPrimary(true);
+				$primary->setParsedLabel('3 is prim(e|ary)');
+				$primary->setLink(
+					'https://en.wikipedia.org/wiki/3#Mathematics',
+					IAction::TYPE_WEB
+				);
+
+				$secondary = $notification->createAction();
+				$secondary->setPrimary(false);
+				$secondary->setParsedLabel('Get status');
+				$secondary->setLink(
+					$this->urlGenerator->getAbsoluteURL('status.php'),
+					IAction::TYPE_GET
+				);
+
+				$three = $notification->createAction();
+				$three->setPrimary(false);
+				$three->setParsedLabel('Delete status.php');
+				$three->setLink(
+					$this->urlGenerator->getAbsoluteURL('status.php'),
+					IAction::TYPE_DELETE
+				);
+
+				$numActions = min(3, $numActions);
+				switch ($numActions) {
+					case 3:
+						$notification->addParsedAction($three);
+						// no break
+					case 2:
+						$notification->addParsedAction($secondary);
+						// no break
+					case 1:
+						$notification->addParsedAction($primary);
+				}
+
+				$notification->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('notifications', 'notifications-dark.svg')));
+				return $notification;
+
 			// Deal with known subjects
 			case 'cli':
 			case 'ocs':

--- a/psalm.xml
+++ b/psalm.xml
@@ -34,4 +34,7 @@
 			</errorLevel>
 		</UndefinedDocblockClass>
 	</issueHandlers>
+	<stubs>
+		<file name="tests/stubs/oc_hooks_emitter.php" />
+	</stubs>
 </psalm>

--- a/tests/Unit/Command/GenerateTest.php
+++ b/tests/Unit/Command/GenerateTest.php
@@ -162,10 +162,11 @@ class GenerateTest extends \Test\TestCase {
 				['user-id', $userId],
 				['short-message', $short],
 			]);
-		$input->expects($this->exactly(1))
+		$input->expects($this->exactly(2))
 			->method('getOption')
 			->willReturnMap([
 				['long-message', $long],
+				['dummy', false],
 			]);
 		$output = $this->createMock(OutputInterface::class);
 

--- a/tests/Unit/Notifier/NotifierTest.php
+++ b/tests/Unit/Notifier/NotifierTest.php
@@ -24,20 +24,27 @@
 namespace OCA\Notifications\Tests\Unit\Notifier;
 
 use OCA\Notifications\Notifier\AdminNotifications;
+use OCP\Files\IRootFolder;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class NotifierTest extends \Test\TestCase {
 	/** @var AdminNotifications */
 	protected $notifier;
 
-	/** @var IFactory|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IFactory|MockObject */
 	protected $factory;
-	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator|MockObject */
 	protected $urlGenerator;
-	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserManager|MockObject */
+	protected $userManager;
+	/** @var IRootFolder|MockObject */
+	protected $rootFolder;
+	/** @var IL10N|MockObject */
 	protected $l;
 
 	protected function setUp(): void {
@@ -54,10 +61,14 @@ class NotifierTest extends \Test\TestCase {
 		$this->factory->expects($this->any())
 			->method('get')
 			->willReturn($this->l);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
 
 		$this->notifier = new AdminNotifications(
 			$this->factory,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->userManager,
+			$this->rootFolder
 		);
 	}
 

--- a/tests/stubs/oc_hooks_emitter.php
+++ b/tests/stubs/oc_hooks_emitter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OC\Hooks {
+	class Emitter {
+		public function emit(string $class, string $value, array $option) {
+		}
+		/** Closure $closure */
+		public function listen(string $class, string $value, $closure) {
+		}
+	}
+}


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/213943/214875559-7d1acfe2-bc66-431e-a3de-4c591b5eb567.png)

This was executed for the screenshot
```sh
occ notification:generate admin 3 --dummy
occ notification:generate admin 1 --dummy
occ notification:generate admin 0 --dummy
```

Relevant docs
```sh
occ notification:generate --help
…
  notification:generate [options] [--] <user-id> <short-message>

Arguments:
  user-id                          User ID of the user to notify
  short-message                    Short message to be sent to the user (max. 255 characters)

Options:
 …
  -d, --dummy                      Create a full-flexed dummy notification for client debugging with actions and parameters (short-message will be casted to integer and is the number of actions (max 3))
…
```