### PR TITLE
chore: Add maintainers as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+/appinfo/info.xml        @Antreesy @nickvergessen
 *                        @nickvergessen


### PR DESCRIPTION
Ref https://github.com/nextcloud/documentation/pull/10049