### PR TITLE
Use the color-primary-element* variables

### DIFF
--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -5,7 +5,7 @@
 			fill: var(--color-warning);
 		}
 		&--white {
-			fill: var(--color-primary-text);
+			fill: var(--color-primary-element-text);
 		}
 	}
 


### PR DESCRIPTION
Explanation: the color-primary variables are not to be used in components because the introduce problems with high-contrast primary colors. Fix this by using the primary-element variables instead.