### PR TITLE
fix(push): Allow apps to provide already parsed notifications

### DIFF
--- a/lib/Push.php
+++ b/lib/Push.php
@@ -306,13 +306,15 @@ class Push {
 		$language = $this->l10nFactory->getUserLanguage($user);
 		$this->printInfo('Language is set to ' . $language);
 
-		try {
-			$this->notificationManager->setPreparingPushNotification(true);
-			$notification = $this->notificationManager->prepare($notification, $language);
-		} catch (\InvalidArgumentException $e) {
-			return;
-		} finally {
-			$this->notificationManager->setPreparingPushNotification(false);
+		if (!$notification->isValidParsed()) {
+			try {
+				$this->notificationManager->setPreparingPushNotification(true);
+				$notification = $this->notificationManager->prepare($notification, $language);
+			} catch (\InvalidArgumentException $e) {
+				return;
+			} finally {
+				$this->notificationManager->setPreparingPushNotification(false);
+			}
 		}
 
 		$userKey = $this->keyManager->getKey($user);


### PR DESCRIPTION
* Ref https://github.com/nextcloud/spreed/issues/11209
* Ref https://github.com/nextcloud/spreed/pull/11218


---

Can be merged already and independently from the Talk PRs and improvements