### PR TITLE
[stable27] fix(deps): Allow composer plugin explicitly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
 		"platform": {
 			"php": "8.0.2"
 		},
-		"sort-packages": true
+		"sort-packages": true,
+		"allow-plugins": {
+			"bamarni/composer-bin-plugin": true
+		}
 	},
 	"scripts": {
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './build/*' -print0 | xargs -0 -n1 php -l",


### PR DESCRIPTION
Fixes:
```

In PluginManager.php line 743:
                                                                                                                                                                            
  bamarni/composer-bin-plugin contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.                 
  You can run "composer config --no-plugins allow-plugins.bamarni/composer-bin-plugin [true|false]" to enable it (true) or disable it explicitly and suppress this excepti  
  on (false)                                                                                                                                                                
  See https://getcomposer.org/allow-plugins                                                                                                                                 
                                                                                                                                                                            

audit [--no-dev] [-f|--format FORMAT] [--locked]
```