### PR TITLE
fix(push): Correctly ignore push tokens that are not valid again

### DIFF
--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -71,7 +71,7 @@ jobs:
           - 4444:3306/tcp
         env:
           MYSQL_ROOT_PASSWORD: rootpassword
-        options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 5
+        options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 10
 
     steps:
       - name: Set app env

--- a/lib/Push.php
+++ b/lib/Push.php
@@ -28,13 +28,13 @@ namespace OCA\Notifications;
 
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
-use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider;
 use OC\Security\IdentityProof\Key;
 use OC\Security\IdentityProof\Manager;
 use OCA\Notifications\AppInfo\Application;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Http\Client\IClientService;
 use OCP\ICache;

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.16.0@2897ba636551a8cb61601cc26f6ccfbba6c36591">
+<files psalm-version="5.21.1@8c473e2437be8b6a8fd8f630f0f11a16b114c494">
   <file src="lib/Controller/PushController.php">
     <UndefinedClass>
       <code>IProvider</code>
@@ -29,7 +29,6 @@
       <code>$e</code>
       <code>ClientException</code>
       <code>IProvider</code>
-      <code>InvalidTokenException</code>
       <code>Key</code>
       <code>Key</code>
       <code>Manager</code>


### PR DESCRIPTION
This seems a bit incorrect in general, as the invalid-password is mostly temporary, but it now behaves the same as in 27 again

Fix #1827 
Fix https://github.com/nextcloud/calendar/issues/5692
Fix https://github.com/nextcloud/server/issues/43547