### PR TITLE
fix(mail): Use parsed action label in email notification

### DIFF
--- a/lib/MailNotifications.php
+++ b/lib/MailNotifications.php
@@ -294,7 +294,7 @@ class MailNotifications {
 				$actions = $notification->getParsedActions();
 				foreach ($actions as $action) {
 					if ($action->getRequestType() === IAction::TYPE_WEB) {
-						$template->addBodyButton($action->getLabel(), $action->getLink());
+						$template->addBodyButton($action->getParsedLabel(), $action->getLink());
 					}
 				}
 			} catch (\Throwable $e) {


### PR DESCRIPTION
Before | After
---|---
![Bildschirmfoto vom 2024-03-05 10-44-49](https://github.com/nextcloud/notifications/assets/213943/53fb3d01-307a-417e-8159-63b664a85d52) | ![Bildschirmfoto vom 2024-03-05 10-43-46](https://github.com/nextcloud/notifications/assets/213943/c1724e38-51d1-40d2-bafb-cc547a649131)
