### PR TITLE
[stable28] chore(deps): audit dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8809,9 +8809,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
-      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
Rest is not fixable with Vue 2.7
```
# npm audit report

postcss  <8.4.31
Severity: moderate
PostCSS line return parsing error - https://github.com/advisories/GHSA-7fh5-64p2-3v2j
No fix available
node_modules/@vue/component-compiler-utils/node_modules/postcss
  @vue/component-compiler-utils  *
  Depends on vulnerable versions of postcss
  node_modules/@vue/component-compiler-utils
    vue-loader  15.0.0-beta.1 - 15.11.1
    Depends on vulnerable versions of @vue/component-compiler-utils
    node_modules/vue-loader
      @nextcloud/webpack-vue-config  *
      Depends on vulnerable versions of vue-loader
      node_modules/@nextcloud/webpack-vue-config

4 moderate severity vulnerabilities
```