### PR TITLE
fix(api): Ignore "parsed" link and icon urls when deleting

### DIFF
--- a/lib/Handler.php
+++ b/lib/Handler.php
@@ -339,14 +339,6 @@ class Handler {
 		if ($notification->getMessage() !== '') {
 			$sql->andWhere($sql->expr()->eq('message', $sql->createNamedParameter($notification->getMessage())));
 		}
-
-		if ($notification->getLink() !== '') {
-			$sql->andWhere($sql->expr()->eq('link', $sql->createNamedParameter($notification->getLink())));
-		}
-
-		if ($notification->getIcon() !== '') {
-			$sql->andWhere($sql->expr()->eq('icon', $sql->createNamedParameter($notification->getIcon())));
-		}
 	}
 
 	/**


### PR DESCRIPTION
Tested on prod for myself after seeing that I had 73 notifications in the database but only 2 displayed in the UI.

The problem is Talk and some others don't have an icon/link stored in the database (as they might change), instead they are added on rendering, e.g. here:
https://github.com/nextcloud/spreed/blob/eb45b2eb8787207d072e5399da50f24f000df658/lib/Notification/Notifier.php#L242-L244

However Talk does this generally up front, so when it later on says "alright, the chat was read already, lets mark the notification as processed":
https://github.com/nextcloud/spreed/blob/eb45b2eb8787207d072e5399da50f24f000df658/lib/Notification/Notifier.php#L487-L498
the data is already manipulated.

Notifications app is then asked to delete the notification, but it adds the non-empty link and icon to the query, they are empty in the DB => No match => No delete

I think it's save to assume that link and icon are never used as "uniqueness" factor and therefore we can ignore them on deletion.