### PR TITLE
fix(exceptions): Catch AlreadyProcessedException as well now

### DIFF
--- a/lib/Controller/EndpointController.php
+++ b/lib/Controller/EndpointController.php
@@ -39,8 +39,10 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IAction;
 use OCP\Notification\IManager;
+use OCP\Notification\IncompleteParsedNotificationException;
 use OCP\Notification\INotification;
 use OCP\UserStatus\IManager as IUserStatusManager;
 use OCP\UserStatus\IUserStatus;
@@ -116,7 +118,8 @@ class EndpointController extends OCSController {
 			/** @var INotification $notification */
 			try {
 				$notification = $this->manager->prepare($notification, $language);
-			} catch (\InvalidArgumentException) {
+			} catch (AlreadyProcessedException|IncompleteParsedNotificationException|\InvalidArgumentException) {
+				// FIXME remove \InvalidArgumentException in Nextcloud 39
 				// The app was disabled, skip the notification
 				continue;
 			}
@@ -170,7 +173,8 @@ class EndpointController extends OCSController {
 
 		try {
 			$notification = $this->manager->prepare($notification, $language);
-		} catch (\InvalidArgumentException $e) {
+		} catch (AlreadyProcessedException|IncompleteParsedNotificationException|\InvalidArgumentException) {
+			// FIXME remove \InvalidArgumentException in Nextcloud 39
 			// The app was disabled
 			return new DataResponse(null, Http::STATUS_NOT_FOUND);
 		}

--- a/lib/MailNotifications.php
+++ b/lib/MailNotifications.php
@@ -38,8 +38,10 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
 use OCP\Mail\IMessage;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IAction;
 use OCP\Notification\IManager;
+use OCP\Notification\IncompleteParsedNotificationException;
 use OCP\Notification\INotification;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
@@ -200,7 +202,8 @@ class MailNotifications {
 			/** @var INotification $preparedNotification */
 			try {
 				$preparedNotification = $this->manager->prepare($notification, $language);
-			} catch (\InvalidArgumentException $e) {
+			} catch (AlreadyProcessedException|IncompleteParsedNotificationException|\InvalidArgumentException) {
+				// FIXME remove \InvalidArgumentException in Nextcloud 39
 				// The app was disabled, skip the notification
 				continue;
 			} catch (\Exception $e) {

--- a/lib/Push.php
+++ b/lib/Push.php
@@ -43,7 +43,9 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\L10N\IFactory;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Notification\IncompleteParsedNotificationException;
 use OCP\Notification\INotification;
 use OCP\UserStatus\IManager as IUserStatusManager;
 use OCP\UserStatus\IUserStatus;
@@ -310,7 +312,8 @@ class Push {
 			try {
 				$this->notificationManager->setPreparingPushNotification(true);
 				$notification = $this->notificationManager->prepare($notification, $language);
-			} catch (\InvalidArgumentException $e) {
+			} catch (AlreadyProcessedException|IncompleteParsedNotificationException|\InvalidArgumentException) {
+				// FIXME remove \InvalidArgumentException in Nextcloud 39
 				return;
 			} finally {
 				$this->notificationManager->setPreparingPushNotification(false);


### PR DESCRIPTION
Follow up to #1882 to fix e.g.
https://github.com/nextcloud/spreed/actions/runs/8686992057/job/23819618008?pr=12110
```json
{"Exception":"OCP\\Notification\\AlreadyProcessedException","Message":"Notification is processed already","Code":0,"Trace":[{"file":"\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/apps\/spreed\/lib\/Notification\/Notifier.php","line":213,"function":"parseRemoteInvitationMessage","class":"OCA\\Talk\\Notification\\Notifier","type":"->","args":[["OC\\Notification\\Notification"],["OC\\L10N\\LazyL10N"]]},{"file":"\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/lib\/private\/Notification\/Manager.php","line":355,"function":"prepare","class":"OCA\\Talk\\Notification\\Notifier","type":"->","args":[["OC\\Notification\\Notification"],"en"]},{"file":"\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/apps\/notifications\/lib\/Controller\/EndpointController.php","line":118,"function":"prepare","class":"OC\\Notification\\Manager","type":"->","args":[["OC\\Notification\\Notification"],"en"]},{"file":"\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":232,"function":"listNotifications","class":"OCA\\Notifications\\Controller\\EndpointController","type":"->","args":["v2"]},{"file":"\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/lib\/private\/AppFramework\/Http\/Dispatcher.php","line":138,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[["OCA\\Notifications\\Controller\\EndpointController"],"listNotifications"]},{"file":"\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/lib\/private\/AppFramework\/App.php","line":184,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[["OCA\\Notifications\\Controller\\EndpointController"],"listNotifications"]},{"file":"\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/lib\/private\/Route\/Router.php","line":338,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OCA\\Notifications\\Controller\\EndpointController","listNotifications",["OC\\AppFramework\\DependencyInjection\\DIContainer"],["v2","ocs.notifications.endpoint.listnotifications"]]},{"file":"\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/ocs\/v1.php","line":66,"function":"match","class":"OC\\Route\\Router","type":"->","args":["\/ocsapp\/apps\/notifications\/api\/v2\/notifications"]},{"file":"\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/ocs\/v2.php","line":23,"args":["\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/ocs\/v1.php"],"function":"require_once"}],"File":"\/home\/runner\/actions-runner\/_work\/spreed\/spreed\/apps\/spreed\/lib\/Notification\/Notifier.php","Line":415,"message":"Notification is processed already","exception":{},"CustomMessage":"Notification is processed already"}
```