### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -921,12 +921,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "325aa38fa5c22df7120e70c495637494a9a7d34f"
+                "reference": "e96b76eddd4c1bea60d41da1e20835806d62923e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/325aa38fa5c22df7120e70c495637494a9a7d34f",
-                "reference": "325aa38fa5c22df7120e70c495637494a9a7d34f",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e96b76eddd4c1bea60d41da1e20835806d62923e",
+                "reference": "e96b76eddd4c1bea60d41da1e20835806d62923e",
                 "shasum": ""
             },
             "require": {
@@ -957,7 +957,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-06-01T00:37:43+00:00"
+            "time": "2024-06-06T00:35:15+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency