### PR TITLE
Add rich object support to API

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -17,7 +17,7 @@ return [
 		['name' => 'Endpoint#deleteAllNotifications', 'url' => '/api/{apiVersion}/notifications', 'verb' => 'DELETE', 'requirements' => ['apiVersion' => '(v1|v2)']],
 
 		['name' => 'API#generateNotification', 'url' => '/api/{apiVersion}/admin_notifications/{userId}', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v1|v2)']],
-		['name' => 'API#generateNotificationV3', 'url' => '/api/{apiVersion}/admin_notifications/{userId}', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v3)']],
+		['name' => 'API#generateNotificationV3', 'url' => '/api/{apiVersion3}/admin_notifications/{userId}', 'verb' => 'POST', 'requirements' => ['apiVersion3' => '(v3)']],
 
 		['name' => 'Settings#personal', 'url' => '/api/{apiVersion}/settings', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'Settings#admin', 'url' => '/api/{apiVersion}/settings/admin', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -17,6 +17,7 @@ return [
 		['name' => 'Endpoint#deleteAllNotifications', 'url' => '/api/{apiVersion}/notifications', 'verb' => 'DELETE', 'requirements' => ['apiVersion' => '(v1|v2)']],
 
 		['name' => 'API#generateNotification', 'url' => '/api/{apiVersion}/admin_notifications/{userId}', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v1|v2)']],
+		['name' => 'API#generateNotificationV3', 'url' => '/api/{apiVersion}/admin_notifications/{userId}', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v3)']],
 
 		['name' => 'Settings#personal', 'url' => '/api/{apiVersion}/settings', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],
 		['name' => 'Settings#admin', 'url' => '/api/{apiVersion}/settings/admin', 'verb' => 'POST', 'requirements' => ['apiVersion' => '(v2)']],

--- a/lib/App.php
+++ b/lib/App.php
@@ -17,6 +17,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class App implements IDeferrableApp {
+	protected ?int $lastInsertedId = null;
 	public function __construct(
 		protected Handler $handler,
 		protected Push $push,
@@ -33,13 +34,17 @@ class App implements IDeferrableApp {
 	 * @since 8.2.0
 	 */
 	public function notify(INotification $notification): void {
-		$notificationId = $this->handler->add($notification);
+		$this->lastInsertedId = $this->handler->add($notification);
 
 		try {
-			$this->push->pushToDevice($notificationId, $notification);
+			$this->push->pushToDevice($this->lastInsertedId, $notification);
 		} catch (NotificationNotFoundException $e) {
 			$this->logger->error('Error while preparing push notification', ['exception' => $e]);
 		}
+	}
+
+	public function getLastInsertedId(): ?int {
+		return $this->lastInsertedId;
 	}
 
 	/**

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Notifications\Controller;
 
 use OCA\Notifications\App;
+use OCA\Notifications\ResponseDefinitions;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\DataResponse;
@@ -24,6 +25,9 @@ use OCP\RichObjectStrings\InvalidObjectExeption;
 use OCP\RichObjectStrings\IValidator;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @psalm-import-type NotificationsRichObjectParameter from ResponseDefinitions
+ */
 class APIController extends OCSController {
 	public function __construct(
 		string $appName,
@@ -75,9 +79,9 @@ class APIController extends OCSController {
 	 * @param string $userId ID of the user
 	 * @param string $subject Subject of the notification
 	 * @param string $message Message of the notification
-	 * @param array $subjectParameters Rich objects to fill the subject placeholders, {@see \OCP\RichObjectStrings\Definitions}
-	 * @param array $messageParameters Rich objects to fill the message placeholders, {@see \OCP\RichObjectStrings\Definitions}
-	 * @return DataResponse<Http::STATUS_OK, array{id: int}, array<string, mixed>>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array<string, mixed>>
+	 * @param array<string, NotificationsRichObjectParameter> $subjectParameters Rich objects to fill the subject placeholders, {@see \OCP\RichObjectStrings\Definitions}
+	 * @param array<string, NotificationsRichObjectParameter> $messageParameters Rich objects to fill the message placeholders, {@see \OCP\RichObjectStrings\Definitions}
+	 * @return DataResponse<Http::STATUS_OK, array{id: int}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array{}>
 	 *
 	 * 200: Notification generated successfully, returned id is the notification ID for future delete requests
 	 * 400: Provided data was invalid, check error field of the response of log file for details

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Notifications\Controller;
 
+use OCA\Notifications\App;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\DataResponse;
@@ -19,8 +20,9 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Notification\IManager;
 use OCP\Notification\InvalidValueException;
-use OCP\RichObjectStrings\IValidator;
 use OCP\RichObjectStrings\InvalidObjectExeption;
+use OCP\RichObjectStrings\IValidator;
+use Psr\Log\LoggerInterface;
 
 class APIController extends OCSController {
 	public function __construct(
@@ -29,60 +31,88 @@ class APIController extends OCSController {
 		protected ITimeFactory $timeFactory,
 		protected IUserManager $userManager,
 		protected IManager $notificationManager,
+		protected App $notificationApp,
 		protected IValidator $richValidator,
+		protected LoggerInterface $logger,
 	) {
 		parent::__construct($appName, $request);
 	}
 
 	/**
-	 * Generate a notification for a user
+	 * Generate a notification for a user (deprecated, use v3 instead)
 	 *
 	 * @param string $userId ID of the user
 	 * @param string $shortMessage Subject of the notification
 	 * @param string $longMessage Message of the notification
-	 * @param string $richSubject Subject of the notification with placeholders
-	 * @param string $richSubjectParameters Rich objects to fill the subject placeholders, {@see \OCP\RichObjectStrings\Definitions}
-	 * @param string $richMessage Message of the notification with placeholders
-	 * @param string $richMessageParameters Rich objects to fill the message placeholders, {@see \OCP\RichObjectStrings\Definitions}
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST|Http::STATUS_NOT_FOUND|Http::STATUS_INTERNAL_SERVER_ERROR, null, array{}>
+	 * @deprecated 30.0.0
 	 *
 	 * 200: Notification generated successfully
 	 * 400: Generating notification is not possible
 	 * 404: User not found
 	 */
 	#[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
-	public function generateNotification(
+	public function generateNotification(string $userId, string $shortMessage, string $longMessage = ''): DataResponse {
+		$response = $this->generateNotificationV3($userId, $shortMessage, $longMessage);
+		if ($response->getStatus() === Http::STATUS_OK) {
+			return new DataResponse();
+		}
+
+		// Translate to old status code
+		$error = $response->getData()['error'] ?? null;
+		$code = match($error) {
+			'user' => Http::STATUS_NOT_FOUND,
+			'subject',
+			'message' => Http::STATUS_BAD_REQUEST,
+			default => Http::STATUS_INTERNAL_SERVER_ERROR,
+		};
+		return new DataResponse(null, $code);
+	}
+
+	/**
+	 * Generate a notification with rich object parameters for a user
+	 *
+	 * @param string $userId ID of the user
+	 * @param string $subject Subject of the notification
+	 * @param string $message Message of the notification
+	 * @param array $subjectParameters Rich objects to fill the subject placeholders, {@see \OCP\RichObjectStrings\Definitions}
+	 * @param array $messageParameters Rich objects to fill the message placeholders, {@see \OCP\RichObjectStrings\Definitions}
+	 * @return DataResponse<Http::STATUS_OK, array{id: int}, array<string, mixed>>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: string}, array<string, mixed>>
+	 *
+	 * 200: Notification generated successfully, returned id is the notification ID for future delete requests
+	 * 400: Provided data was invalid, check error field of the response of log file for details
+	 */
+	#[OpenAPI(scope: OpenAPI::SCOPE_ADMINISTRATION)]
+	public function generateNotificationV3(
 		string $userId,
-		string $shortMessage = '',
-		string $longMessage = '',
-		string $richSubject = '',
-		array $richSubjectParameters = [],
-		string $richMessage = '',
-		array $richMessageParameters = [],
+		string $subject = '',
+		string $message = '',
+		array $subjectParameters = [],
+		array $messageParameters = [],
 	): DataResponse {
 		$user = $this->userManager->get($userId);
 
 		if (!$user instanceof IUser) {
-			return new DataResponse(null, Http::STATUS_NOT_FOUND);
+			return new DataResponse(['error' => 'user'], Http::STATUS_BAD_REQUEST);
 		}
 
-		if (($shortMessage === '' && $richSubject === '') || strlen($shortMessage) > 255) {
-			return new DataResponse(null, Http::STATUS_BAD_REQUEST);
+		if ($subject === '' || strlen($subject) > 255) {
+			return new DataResponse(['error' => 'subject'], Http::STATUS_BAD_REQUEST);
 		}
 
-		if ($longMessage !== '' && strlen($longMessage) > 4000) {
-			return new DataResponse(null, Http::STATUS_BAD_REQUEST);
+		if ($message !== '' && strlen($message) > 4000) {
+			return new DataResponse(['error' => 'message'], Http::STATUS_BAD_REQUEST);
 		}
 
 		$notification = $this->notificationManager->createNotification();
 		$datetime = $this->timeFactory->getDateTime();
 
 		try {
-			if ($richSubject !== '') {
-				$this->richValidator->validate($richSubject, $richSubjectParameters);
+			if (!empty($subjectParameters)) {
+				$this->richValidator->validate($subject, $subjectParameters);
 			}
-			if ($richMessage !== '') {
-				$this->richValidator->validate($richMessage, $richMessageParameters);
+			if ($message !== '' && !empty($messageParameters)) {
+				$this->richValidator->validate($message, $messageParameters);
 			}
 			$notification->setApp('admin_notifications')
 				->setUser($user->getUID())
@@ -91,32 +121,30 @@ class APIController extends OCSController {
 				->setSubject(
 					'ocs',
 					[
-						'parsed' => $shortMessage,
-						'rich' => $richSubject,
-						'parameters' => $richSubjectParameters,
+						'subject' => $subject,
+						'parameters' => $subjectParameters,
 					]
 				);
 
-			if ($longMessage !== '' || $richMessage !== '') {
+			if ($message !== '') {
 				$notification->setMessage(
 					'ocs',
 					[
-						'parsed' => $longMessage,
-						'rich' => $richMessage,
-						'parameters' => $richMessageParameters,
+						'message' => $message,
+						'parameters' => $messageParameters,
 					]
 				);
 			}
 
 			$this->notificationManager->notify($notification);
 		} catch (InvalidObjectExeption $e) {
-			return new DataResponse('Invalid rich object: '.$e->getMessage(), Http::STATUS_BAD_REQUEST);
+			$this->logger->error('Invalid rich object parameter provided: ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(['error' => 'parameters'], Http::STATUS_BAD_REQUEST);
 		} catch (InvalidValueException $e) {
-			return new DataResponse($e->getMessage(), Http::STATUS_BAD_REQUEST);
-		} catch (\InvalidArgumentException) {
-			return new DataResponse(null, Http::STATUS_INTERNAL_SERVER_ERROR);
+			$this->logger->error('Invalid value for notification provided: ' . $e->getMessage(), ['exception' => $e]);
+			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 
-		return new DataResponse();
+		return new DataResponse(['id' => (int) $this->notificationApp->getLastInsertedId()]);
 	}
 }

--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -20,6 +20,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Notification\IManager;
+use OCP\Notification\IncompleteNotificationException;
 use OCP\Notification\InvalidValueException;
 use OCP\RichObjectStrings\InvalidObjectExeption;
 use OCP\RichObjectStrings\IValidator;
@@ -144,7 +145,7 @@ class APIController extends OCSController {
 		} catch (InvalidObjectExeption $e) {
 			$this->logger->error('Invalid rich object parameter provided: ' . $e->getMessage(), ['exception' => $e]);
 			return new DataResponse(['error' => 'parameters'], Http::STATUS_BAD_REQUEST);
-		} catch (InvalidValueException $e) {
+		} catch (InvalidValueException|IncompleteNotificationException $e) {
 			$this->logger->error('Invalid value for notification provided: ' . $e->getMessage(), ['exception' => $e]);
 			return new DataResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Notifier/AdminNotifications.php
+++ b/lib/Notifier/AdminNotifications.php
@@ -176,10 +176,20 @@ class AdminNotifications implements INotifier {
 			case 'cli':
 			case 'ocs':
 				$subjectParams = $notification->getSubjectParameters();
-				$notification->setParsedSubject($subjectParams[0]);
+				if ($subjectParams['parsed'] !== '') {
+					$notification->setParsedSubject($subjectParams['parsed']);
+				}
+				if ($subjectParams['rich'] !== '') {
+					$notification->setRichSubject($subjectParams['rich'], $subjectParams['parameters']);
+				}
 				$messageParams = $notification->getMessageParameters();
-				if (isset($messageParams[0]) && $messageParams[0] !== '') {
-					$notification->setParsedMessage($messageParams[0]);
+				if (!empty($messageParams)) {
+					if ($messageParams['parsed'] !== '') {
+						$notification->setParsedMessage($messageParams['parsed']);
+					}
+					if ($messageParams['rich'] !== '') {
+						$notification->setRichMessage($messageParams['rich'], $messageParams['parameters']);
+					}
 				}
 
 				$notification->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('notifications', 'notifications-dark.svg')));

--- a/lib/Notifier/AdminNotifications.php
+++ b/lib/Notifier/AdminNotifications.php
@@ -176,19 +176,21 @@ class AdminNotifications implements INotifier {
 			case 'cli':
 			case 'ocs':
 				$subjectParams = $notification->getSubjectParameters();
-				if ($subjectParams['parsed'] !== '') {
-					$notification->setParsedSubject($subjectParams['parsed']);
-				}
-				if ($subjectParams['rich'] !== '') {
-					$notification->setRichSubject($subjectParams['rich'], $subjectParams['parameters']);
+				if (isset($subjectParams['subject'])) {
+					// Nextcloud 30+
+					$notification->setRichSubject($subjectParams['subject'], $subjectParams['parameters']);
+				} else {
+					// Legacy before Nextcloud 30 (v3)
+					$notification->setParsedSubject($subjectParams[0]);
 				}
 				$messageParams = $notification->getMessageParameters();
 				if (!empty($messageParams)) {
-					if ($messageParams['parsed'] !== '') {
-						$notification->setParsedMessage($messageParams['parsed']);
-					}
-					if ($messageParams['rich'] !== '') {
-						$notification->setRichMessage($messageParams['rich'], $messageParams['parameters']);
+					if (!empty($messageParams['message'])) {
+						// Nextcloud 30+
+						$notification->setRichMessage($messageParams['message'], $messageParams['parameters']);
+					} elseif (!empty($messageParams[0])) {
+						// Legacy before Nextcloud 30 (v3)
+						$notification->setParsedMessage($messageParams[0]);
 					}
 				}
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -10,6 +10,36 @@ declare(strict_types=1);
 namespace OCA\Notifications;
 
 /**
+ * @psalm-type NotificationsRichObjectParameter = array{
+ *     type: string,
+ *     id: string,
+ *     name: string,
+ *     server?: string,
+ *     link?: string,
+ *     'call-type'?: 'one2one'|'group'|'public',
+ *     'icon-url'?: string,
+ *     'message-id'?: string,
+ *     boardname?: string,
+ *     stackname?: string,
+ *     size?: string,
+ *     path?: string,
+ *     mimetype?: string,
+ *     'preview-available'?: 'yes'|'no',
+ *     mtime?: string,
+ *     latitude?: string,
+ *     longitude?: string,
+ *     description?: string,
+ *     thumb?: string,
+ *     website?: string,
+ *     visibility?: '0'|'1',
+ *     assignable?: '0'|'1',
+ *     conversation?: string,
+ *     etag?: string,
+ *     permissions?: string,
+ *     width?: string,
+ *     height?: string,
+ * }
+ *
  * @psalm-type NotificationsNotificationAction = array{
  *     label: string,
  *     link: string,
@@ -29,9 +59,9 @@ namespace OCA\Notifications;
  *     link: string,
  *     actions: NotificationsNotificationAction[],
  *     subjectRich?: string,
- *     subjectRichParameters?: array<string, mixed>,
+ *     subjectRichParameters?: array<string, NotificationsRichObjectParameter>,
  *     messageRich?: string,
- *     messageRichParameters?: array<string, mixed>,
+ *     messageRichParameters?: array<string, NotificationsRichObjectParameter>,
  *     icon?: string,
  *     shouldNotify?: bool,
  * }

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -86,8 +86,9 @@
         "/ocs/v2.php/apps/notifications/api/{apiVersion}/admin_notifications/{userId}": {
             "post": {
                 "operationId": "api-generate-notification",
-                "summary": "Generate a notification for a user",
+                "summary": "Generate a notification for a user (deprecated, use v3 instead)",
                 "description": "This endpoint requires admin access",
+                "deprecated": true,
                 "tags": [
                     "api"
                 ],
@@ -99,25 +100,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "shortMessage"
+                                ],
+                                "properties": {
+                                    "shortMessage": {
+                                        "type": "string",
+                                        "description": "Subject of the notification"
+                                    },
+                                    "longMessage": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Message of the notification"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "shortMessage",
-                        "in": "query",
-                        "description": "Subject of the notification",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "longMessage",
-                        "in": "query",
-                        "description": "Message of the notification",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -273,6 +280,171 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion3}/admin_notifications/{userId}": {
+            "post": {
+                "operationId": "api-generate-notification-v3",
+                "summary": "Generate a notification with rich object parameters for a user",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "api"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "subject": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Subject of the notification"
+                                    },
+                                    "message": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Message of the notification"
+                                    },
+                                    "subjectParameters": {
+                                        "type": "object",
+                                        "default": [],
+                                        "description": "Rich objects to fill the subject placeholders, {@see \\OCP\\RichObjectStrings\\Definitions}",
+                                        "additionalProperties": {
+                                            "$ref": "#/components/schemas/RichObjectParameter"
+                                        }
+                                    },
+                                    "messageParameters": {
+                                        "type": "object",
+                                        "default": [],
+                                        "description": "Rich objects to fill the message placeholders, {@see \\OCP\\RichObjectStrings\\Definitions}",
+                                        "additionalProperties": {
+                                            "$ref": "#/components/schemas/RichObjectParameter"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion3",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^(v3)$"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "ID of the user",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Notification generated successfully, returned id is the notification ID for future delete requests",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "id"
+                                                    ],
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "integer",
+                                                            "format": "int64"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Provided data was invalid, check error field of the response of log file for details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "error"
+                                                    ],
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/notifications/api/{apiVersion}/settings/admin": {
             "post": {
                 "operationId": "settings-admin",
@@ -289,35 +461,37 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "batchSetting",
+                                    "soundNotification",
+                                    "soundTalk"
+                                ],
+                                "properties": {
+                                    "batchSetting": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)"
+                                    },
+                                    "soundNotification": {
+                                        "type": "string",
+                                        "description": "Enable sound for notifications ('yes' or 'no')"
+                                    },
+                                    "soundTalk": {
+                                        "type": "string",
+                                        "description": "Enable sound for Talk notifications ('yes' or 'no')"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "batchSetting",
-                        "in": "query",
-                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "soundNotification",
-                        "in": "query",
-                        "description": "Enable sound for notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "soundTalk",
-                        "in": "query",
-                        "description": "Enable sound for Talk notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -111,7 +111,7 @@
                     "subjectRichParameters": {
                         "type": "object",
                         "additionalProperties": {
-                            "type": "object"
+                            "$ref": "#/components/schemas/RichObjectParameter"
                         }
                     },
                     "messageRich": {
@@ -120,7 +120,7 @@
                     "messageRichParameters": {
                         "type": "object",
                         "additionalProperties": {
-                            "type": "object"
+                            "$ref": "#/components/schemas/RichObjectParameter"
                         }
                     },
                     "icon": {
@@ -193,6 +193,114 @@
                         "type": "string"
                     },
                     "signature": {
+                        "type": "string"
+                    }
+                }
+            },
+            "RichObjectParameter": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "id",
+                    "name"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "server": {
+                        "type": "string"
+                    },
+                    "link": {
+                        "type": "string"
+                    },
+                    "call-type": {
+                        "type": "string",
+                        "enum": [
+                            "one2one",
+                            "group",
+                            "public"
+                        ]
+                    },
+                    "icon-url": {
+                        "type": "string"
+                    },
+                    "message-id": {
+                        "type": "string"
+                    },
+                    "boardname": {
+                        "type": "string"
+                    },
+                    "stackname": {
+                        "type": "string"
+                    },
+                    "size": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string"
+                    },
+                    "mimetype": {
+                        "type": "string"
+                    },
+                    "preview-available": {
+                        "type": "string",
+                        "enum": [
+                            "yes",
+                            "no"
+                        ]
+                    },
+                    "mtime": {
+                        "type": "string"
+                    },
+                    "latitude": {
+                        "type": "string"
+                    },
+                    "longitude": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "thumb": {
+                        "type": "string"
+                    },
+                    "website": {
+                        "type": "string"
+                    },
+                    "visibility": {
+                        "type": "string",
+                        "enum": [
+                            "0",
+                            "1"
+                        ]
+                    },
+                    "assignable": {
+                        "type": "string",
+                        "enum": [
+                            "0",
+                            "1"
+                        ]
+                    },
+                    "conversation": {
+                        "type": "string"
+                    },
+                    "etag": {
+                        "type": "string"
+                    },
+                    "permissions": {
+                        "type": "string"
+                    },
+                    "width": {
+                        "type": "string"
+                    },
+                    "height": {
                         "type": "string"
                     }
                 }
@@ -665,20 +773,30 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "ids[]",
-                        "in": "query",
-                        "description": "IDs of the notifications to check",
-                        "required": true,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "integer",
-                                "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "ids"
+                                ],
+                                "properties": {
+                                    "ids": {
+                                        "type": "array",
+                                        "description": "IDs of the notifications to check",
+                                        "items": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -791,35 +909,37 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "batchSetting",
+                                    "soundNotification",
+                                    "soundTalk"
+                                ],
+                                "properties": {
+                                    "batchSetting": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)"
+                                    },
+                                    "soundNotification": {
+                                        "type": "string",
+                                        "description": "Enable sound for notifications ('yes' or 'no')"
+                                    },
+                                    "soundTalk": {
+                                        "type": "string",
+                                        "description": "Enable sound for Talk notifications ('yes' or 'no')"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "batchSetting",
-                        "in": "query",
-                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "soundNotification",
-                        "in": "query",
-                        "description": "Enable sound for notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "soundTalk",
-                        "in": "query",
-                        "description": "Enable sound for Talk notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -878,8 +998,9 @@
         "/ocs/v2.php/apps/notifications/api/{apiVersion}/admin_notifications/{userId}": {
             "post": {
                 "operationId": "api-generate-notification",
-                "summary": "Generate a notification for a user",
+                "summary": "Generate a notification for a user (deprecated, use v3 instead)",
                 "description": "This endpoint requires admin access",
+                "deprecated": true,
                 "tags": [
                     "api"
                 ],
@@ -891,25 +1012,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "shortMessage"
+                                ],
+                                "properties": {
+                                    "shortMessage": {
+                                        "type": "string",
+                                        "description": "Subject of the notification"
+                                    },
+                                    "longMessage": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Message of the notification"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "shortMessage",
-                        "in": "query",
-                        "description": "Subject of the notification",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "longMessage",
-                        "in": "query",
-                        "description": "Message of the notification",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1065,6 +1192,171 @@
                 }
             }
         },
+        "/ocs/v2.php/apps/notifications/api/{apiVersion3}/admin_notifications/{userId}": {
+            "post": {
+                "operationId": "api-generate-notification-v3",
+                "summary": "Generate a notification with rich object parameters for a user",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "api"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "subject": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Subject of the notification"
+                                    },
+                                    "message": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Message of the notification"
+                                    },
+                                    "subjectParameters": {
+                                        "type": "object",
+                                        "default": [],
+                                        "description": "Rich objects to fill the subject placeholders, {@see \\OCP\\RichObjectStrings\\Definitions}",
+                                        "additionalProperties": {
+                                            "$ref": "#/components/schemas/RichObjectParameter"
+                                        }
+                                    },
+                                    "messageParameters": {
+                                        "type": "object",
+                                        "default": [],
+                                        "description": "Rich objects to fill the message placeholders, {@see \\OCP\\RichObjectStrings\\Definitions}",
+                                        "additionalProperties": {
+                                            "$ref": "#/components/schemas/RichObjectParameter"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "apiVersion3",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^(v3)$"
+                        }
+                    },
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "ID of the user",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Notification generated successfully, returned id is the notification ID for future delete requests",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "id"
+                                                    ],
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "integer",
+                                                            "format": "int64"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Provided data was invalid, check error field of the response of log file for details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "error"
+                                                    ],
+                                                    "properties": {
+                                                        "error": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/apps/notifications/api/{apiVersion}/settings/admin": {
             "post": {
                 "operationId": "settings-admin",
@@ -1081,35 +1373,37 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "batchSetting",
+                                    "soundNotification",
+                                    "soundTalk"
+                                ],
+                                "properties": {
+                                    "batchSetting": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)"
+                                    },
+                                    "soundNotification": {
+                                        "type": "string",
+                                        "description": "Enable sound for notifications ('yes' or 'no')"
+                                    },
+                                    "soundTalk": {
+                                        "type": "string",
+                                        "description": "Enable sound for Talk notifications ('yes' or 'no')"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "batchSetting",
-                        "in": "query",
-                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "soundNotification",
-                        "in": "query",
-                        "description": "Enable sound for notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "soundTalk",
-                        "in": "query",
-                        "description": "Enable sound for Talk notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1180,34 +1474,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "pushTokenHash",
+                                    "devicePublicKey",
+                                    "proxyServer"
+                                ],
+                                "properties": {
+                                    "pushTokenHash": {
+                                        "type": "string",
+                                        "description": "Hash of the push token"
+                                    },
+                                    "devicePublicKey": {
+                                        "type": "string",
+                                        "description": "Public key of the device"
+                                    },
+                                    "proxyServer": {
+                                        "type": "string",
+                                        "description": "Proxy server to be used"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "pushTokenHash",
-                        "in": "query",
-                        "description": "Hash of the push token",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "devicePublicKey",
-                        "in": "query",
-                        "description": "Public key of the device",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "proxyServer",
-                        "in": "query",
-                        "description": "Proxy server to be used",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",

--- a/openapi-push.json
+++ b/openapi-push.json
@@ -117,34 +117,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "pushTokenHash",
+                                    "devicePublicKey",
+                                    "proxyServer"
+                                ],
+                                "properties": {
+                                    "pushTokenHash": {
+                                        "type": "string",
+                                        "description": "Hash of the push token"
+                                    },
+                                    "devicePublicKey": {
+                                        "type": "string",
+                                        "description": "Public key of the device"
+                                    },
+                                    "proxyServer": {
+                                        "type": "string",
+                                        "description": "Proxy server to be used"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "pushTokenHash",
-                        "in": "query",
-                        "description": "Hash of the push token",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "devicePublicKey",
-                        "in": "query",
-                        "description": "Public key of the device",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "proxyServer",
-                        "in": "query",
-                        "description": "Proxy server to be used",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",

--- a/openapi.json
+++ b/openapi.json
@@ -111,7 +111,7 @@
                     "subjectRichParameters": {
                         "type": "object",
                         "additionalProperties": {
-                            "type": "object"
+                            "$ref": "#/components/schemas/RichObjectParameter"
                         }
                     },
                     "messageRich": {
@@ -120,7 +120,7 @@
                     "messageRichParameters": {
                         "type": "object",
                         "additionalProperties": {
-                            "type": "object"
+                            "$ref": "#/components/schemas/RichObjectParameter"
                         }
                     },
                     "icon": {
@@ -174,6 +174,114 @@
                         "type": "string"
                     },
                     "itemsperpage": {
+                        "type": "string"
+                    }
+                }
+            },
+            "RichObjectParameter": {
+                "type": "object",
+                "required": [
+                    "type",
+                    "id",
+                    "name"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "server": {
+                        "type": "string"
+                    },
+                    "link": {
+                        "type": "string"
+                    },
+                    "call-type": {
+                        "type": "string",
+                        "enum": [
+                            "one2one",
+                            "group",
+                            "public"
+                        ]
+                    },
+                    "icon-url": {
+                        "type": "string"
+                    },
+                    "message-id": {
+                        "type": "string"
+                    },
+                    "boardname": {
+                        "type": "string"
+                    },
+                    "stackname": {
+                        "type": "string"
+                    },
+                    "size": {
+                        "type": "string"
+                    },
+                    "path": {
+                        "type": "string"
+                    },
+                    "mimetype": {
+                        "type": "string"
+                    },
+                    "preview-available": {
+                        "type": "string",
+                        "enum": [
+                            "yes",
+                            "no"
+                        ]
+                    },
+                    "mtime": {
+                        "type": "string"
+                    },
+                    "latitude": {
+                        "type": "string"
+                    },
+                    "longitude": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "thumb": {
+                        "type": "string"
+                    },
+                    "website": {
+                        "type": "string"
+                    },
+                    "visibility": {
+                        "type": "string",
+                        "enum": [
+                            "0",
+                            "1"
+                        ]
+                    },
+                    "assignable": {
+                        "type": "string",
+                        "enum": [
+                            "0",
+                            "1"
+                        ]
+                    },
+                    "conversation": {
+                        "type": "string"
+                    },
+                    "etag": {
+                        "type": "string"
+                    },
+                    "permissions": {
+                        "type": "string"
+                    },
+                    "width": {
+                        "type": "string"
+                    },
+                    "height": {
                         "type": "string"
                     }
                 }
@@ -646,20 +754,30 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "ids[]",
-                        "in": "query",
-                        "description": "IDs of the notifications to check",
-                        "required": true,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "integer",
-                                "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "ids"
+                                ],
+                                "properties": {
+                                    "ids": {
+                                        "type": "array",
+                                        "description": "IDs of the notifications to check",
+                                        "items": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -772,35 +890,37 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "batchSetting",
+                                    "soundNotification",
+                                    "soundTalk"
+                                ],
+                                "properties": {
+                                    "batchSetting": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)"
+                                    },
+                                    "soundNotification": {
+                                        "type": "string",
+                                        "description": "Enable sound for notifications ('yes' or 'no')"
+                                    },
+                                    "soundTalk": {
+                                        "type": "string",
+                                        "description": "Enable sound for Talk notifications ('yes' or 'no')"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "batchSetting",
-                        "in": "query",
-                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "soundNotification",
-                        "in": "query",
-                        "description": "Enable sound for notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "soundTalk",
-                        "in": "query",
-                        "description": "Enable sound for Talk notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",

--- a/tests/Unit/AppInfo/RoutesTest.php
+++ b/tests/Unit/AppInfo/RoutesTest.php
@@ -21,6 +21,6 @@ class RoutesTest extends TestCase {
 		$this->assertCount(1, $routes);
 		$this->assertArrayHasKey('ocs', $routes);
 		$this->assertIsArray($routes['ocs']);
-		$this->assertCount(8, $routes['ocs']);
+		$this->assertCount(9, $routes['ocs']);
 	}
 }

--- a/vendor-bin/openapi-extractor/composer.lock
+++ b/vendor-bin/openapi-extractor/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "adhocore/cli",
-            "version": "v1.6.2",
+            "version": "v1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/adhocore/php-cli.git",
-                "reference": "34191315b0da20b9b4ecad783d91db992fa209a4"
+                "reference": "3fde60a838912e71c82ed0f48048685dc32dbc77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/adhocore/php-cli/zipball/34191315b0da20b9b4ecad783d91db992fa209a4",
-                "reference": "34191315b0da20b9b4ecad783d91db992fa209a4",
+                "url": "https://api.github.com/repos/adhocore/php-cli/zipball/3fde60a838912e71c82ed0f48048685dc32dbc77",
+                "reference": "3fde60a838912e71c82ed0f48048685dc32dbc77",
                 "shasum": ""
             },
             "require": {
@@ -62,7 +62,7 @@
             ],
             "support": {
                 "issues": "https://github.com/adhocore/php-cli/issues",
-                "source": "https://github.com/adhocore/php-cli/tree/v1.6.2"
+                "source": "https://github.com/adhocore/php-cli/tree/v1.7.1"
             },
             "funding": [
                 {
@@ -74,7 +74,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-01-22T22:37:23+00:00"
+            "time": "2024-03-28T08:30:12+00:00"
         },
         {
             "name": "nextcloud/openapi-extractor",
@@ -82,23 +82,24 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/openapi-extractor.git",
-                "reference": "ecf189df4c930cd21acbef0984f5ca7bc3a7e5ab"
+                "reference": "944c6a64e428705eea138dcfce4e5b95b126448d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud/openapi-extractor/zipball/ecf189df4c930cd21acbef0984f5ca7bc3a7e5ab",
-                "reference": "ecf189df4c930cd21acbef0984f5ca7bc3a7e5ab",
+                "url": "https://api.github.com/repos/nextcloud/openapi-extractor/zipball/944c6a64e428705eea138dcfce4e5b95b126448d",
+                "reference": "944c6a64e428705eea138dcfce4e5b95b126448d",
                 "shasum": ""
             },
             "require": {
-                "adhocore/cli": "^v1.6",
+                "adhocore/cli": "^1.7",
                 "ext-simplexml": "*",
-                "nikic/php-parser": "^4.16",
+                "nikic/php-parser": "^5.0",
                 "php": "^8.1",
-                "phpstan/phpdoc-parser": "^1.23"
+                "phpstan/phpdoc-parser": "^1.28"
             },
             "require-dev": {
-                "nextcloud/coding-standard": "^1.1"
+                "nextcloud/coding-standard": "^1.2",
+                "nextcloud/ocp": "dev-master"
             },
             "default-branch": true,
             "bin": [
@@ -129,29 +130,31 @@
                 "source": "https://github.com/nextcloud/openapi-extractor/tree/main",
                 "issues": "https://github.com/nextcloud/openapi-extractor/issues"
             },
-            "time": "2024-04-08T14:19:17+00:00"
+            "time": "2024-07-06T04:06:45+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.18.0",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -159,7 +162,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -183,22 +186,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2023-12-10T21:03:43+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.25.0",
+            "version": "1.29.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240"
+                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bd84b629c8de41aa2ae82c067c955e06f1b00240",
-                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fcaefacf2d5c417e928405b71b400d4ce10daaf4",
+                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4",
                 "shasum": ""
             },
             "require": {
@@ -230,9 +233,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.25.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.1"
             },
-            "time": "2024-01-04T17:06:16+00:00"
+            "time": "2024-05-31T08:52:43+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Add rich object support to both subject and message in the API to create notifications from an admin account.

# TODO:

- [x] Notifier should be backward compatible with old notification in DB (so support key `0` instead of `'parsed'`)
- [x] Should this be moved to an other endpoint or a new apiVersion number to make it simpler (ie not have both shortMessage and richSubject but only one of them and so on) ?
- [x] Fix tests and add some for the new features
- [x] ~Should we allow to set icon?~
- [x] Add support for adding actions, **in a followup PR**