### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -921,12 +921,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "74645201388ba3e2891b364e526de90cf710949e"
+                "reference": "bfdd4dcddff043a016cf0cf937018c70618b8a01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/74645201388ba3e2891b364e526de90cf710949e",
-                "reference": "74645201388ba3e2891b364e526de90cf710949e",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/bfdd4dcddff043a016cf0cf937018c70618b8a01",
+                "reference": "bfdd4dcddff043a016cf0cf937018c70618b8a01",
                 "shasum": ""
             },
             "require": {
@@ -957,7 +957,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-07-11T00:37:33+00:00"
+            "time": "2024-07-26T00:37:14+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency