### PR TITLE
Unified push nextcloud notifications

### DIFF
--- a/lib/App.php
+++ b/lib/App.php
@@ -43,6 +43,12 @@ class App implements IDeferrableApp {
 		}
 	}
 
+  public function notifyDelete(string $user, ?int $id, ?INotification $notification): void {
+    $idAsArray = ($id !== null) ? [ $id ] : null;
+    $appName = ($notification !== null) ? $notification->getApp() : "";
+    $this->push->pushDeleteToDevice($user, $idAsArray, $appName);
+  }
+
 	public function getLastInsertedId(): ?int {
 		return $this->lastInsertedId;
 	}

--- a/lib/App.php
+++ b/lib/App.php
@@ -43,11 +43,11 @@ class App implements IDeferrableApp {
 		}
 	}
 
-  public function notifyDelete(string $user, ?int $id, ?INotification $notification): void {
-    $idAsArray = ($id !== null) ? [ $id ] : null;
-    $appName = ($notification !== null) ? $notification->getApp() : "";
-    $this->push->pushDeleteToDevice($user, $idAsArray, $appName);
-  }
+	public function notifyDelete(string $user, ?int $id, ?INotification $notification): void {
+		$idAsArray = ($id !== null) ? [ $id ] : null;
+		$appName = ($notification !== null) ? $notification->getApp() : "";
+		$this->push->pushDeleteToDevice($user, $idAsArray, $appName);
+	}
 
 	public function getLastInsertedId(): ?int {
 		return $this->lastInsertedId;

--- a/lib/Controller/EndpointController.php
+++ b/lib/Controller/EndpointController.php
@@ -229,7 +229,7 @@ class EndpointController extends OCSController {
 			$deleted = $this->handler->deleteById($id, $this->getCurrentUser(), $notification);
 
 			if ($deleted) {
-        $this->manager->notifyDelete($this->getCurrentUser(), $id, $notification);
+				$this->manager->notifyDelete($this->getCurrentUser(), $id, $notification);
 			}
 		} catch (NotificationNotFoundException $e) {
 		}

--- a/lib/Controller/EndpointController.php
+++ b/lib/Controller/EndpointController.php
@@ -229,7 +229,7 @@ class EndpointController extends OCSController {
 			$deleted = $this->handler->deleteById($id, $this->getCurrentUser(), $notification);
 
 			if ($deleted) {
-				$this->push->pushDeleteToDevice($this->getCurrentUser(), [$id], $notification->getApp());
+        $this->manager->notifyDelete($this->getCurrentUser(), $id, $notification);
 			}
 		} catch (NotificationNotFoundException $e) {
 		}
@@ -255,7 +255,7 @@ class EndpointController extends OCSController {
 
 		$deletedSomething = $this->handler->deleteByUser($this->getCurrentUser());
 		if ($deletedSomething) {
-			$this->push->pushDeleteToDevice($this->getCurrentUser(), null);
+			$this->manager->notifyDelete($this->getCurrentUser(), null, null);
 		}
 
 		if ($shouldFlush) {


### PR DESCRIPTION
minimal changes to set the stage to allow the existing 3rd party nextcloud unified push app to send system notifications as push notifications to nextcloud mobile client and talk apps - https://apps.nextcloud.com/apps/uppush / https://codeberg.org/NextPush/uppush.

requires deployment sync with pull request for nextcloud server with same title - Unified push nextcloud notifications - https://github.com/nextcloud/server/pull/47763

these pull requests are independent of, but will ultimately work with, a pull request for the unified push app to enable it to send push notifications to the nextcloud mobile client and talk apps - https://codeberg.org/NextPush/uppush/pulls/17

i have also submitted pr's for the generic (f-droid) android nextcloud client and talk apps to leverage the pr's above to create an end-to-end solution for unified push notifications and talk;

nextcloud mobile client app: https://github.com/nextcloud/android/pull/13516
nextcloud mobile talk app: https://github.com/nextcloud/talk-android/pull/4169

* this pr fails ci tests because it depends on the related notification app pr