### PR TITLE
fix(APIController): Allow self-test depending on token and not user-agent

### DIFF
--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -189,18 +189,6 @@ class APIController extends OCSController {
 			);
 		}
 
-		if (!$this->request->isUserAgent([
-			IRequest::USER_AGENT_TALK_ANDROID,
-			IRequest::USER_AGENT_TALK_IOS,
-			IRequest::USER_AGENT_CLIENT_ANDROID,
-			IRequest::USER_AGENT_CLIENT_IOS,
-		])) {
-			return new DataResponse(
-				['message' => $this->l->t('The device does not seem to be supported')],
-				Http::STATUS_BAD_REQUEST,
-			);
-		}
-
 		$notification = $this->notificationManager->createNotification();
 		$datetime = $this->timeFactory->getDateTime();
 		$isTalkApp = $this->request->isUserAgent([


### PR DESCRIPTION
I would also like to use this endpoint without having a matching user-agent.
The token is a better method to verify the client can even handle push notifications, because in order to have a valid token it already needs to be registered for push notifications.