### PR TITLE
chore(tests): Cleanup bootstrap.php to be forward-compatible

### DIFF
--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -1,19 +1,23 @@
 <?php
+
+declare(strict_types=1);
+
 /**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
+use OCP\App\IAppManager;
+use OCP\Server;
 
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
 
 require_once __DIR__ . '/../../../../lib/base.php';
+require_once __DIR__ . '/../../../../tests/autoload.php';
 
-// Fix for "Autoload path not allowed: .../tests/lib/testcase.php"
-\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
-
-// Fix for "Autoload path not allowed: .../notifications/tests/testcase.php"
-\OC_App::loadApp('notifications');
+Server::get(IAppManager::class)->loadApp('notifications');
 
 OC_Hook::clear();

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -19,5 +19,3 @@ require_once __DIR__ . '/../../../../lib/base.php';
 require_once __DIR__ . '/../../../../tests/autoload.php';
 
 Server::get(IAppManager::class)->loadApp('notifications');
-
-OC_Hook::clear();


### PR DESCRIPTION
This uses the new tests/autoload.php from nextcloud/server instead of messing directly with OC private autoloader.

See https://github.com/nextcloud/server/pull/52951 and https://github.com/nextcloud/server/pull/52945 for context.