### PR TITLE
ci: Skip printing the log as we count the queries and upload it already

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -165,9 +165,6 @@ jobs:
         working-directory: apps/${{ env.APP_NAME }}
         run: composer run test:integration
 
-      - name: Print query.log
-        run: cat query.log
-
       - name: Upload query.log
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:


### PR DESCRIPTION
- Proofing https://github.com/nextcloud/notifications/issues/2353
- By testing https://github.com/nextcloud/server/pull/52971