### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "c40c9b653f4546bf8de73b3c97dba11a8143aaaa"
+                "reference": "2c063a31872529f40b430f95ea38ec704d82660c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c40c9b653f4546bf8de73b3c97dba11a8143aaaa",
-                "reference": "c40c9b653f4546bf8de73b3c97dba11a8143aaaa",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/2c063a31872529f40b430f95ea38ec704d82660c",
+                "reference": "2c063a31872529f40b430f95ea38ec704d82660c",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-05-24T00:49:26+00:00"
+            "time": "2025-05-27T00:51:09+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency