### PR TITLE
feat(APIController): Return nid when doing push self-test

### DIFF
--- a/lib/Controller/APIController.php
+++ b/lib/Controller/APIController.php
@@ -165,7 +165,7 @@ class APIController extends OCSController {
 	 *
 	 * Required capability: `ocs-endpoints > test-push`
 	 *
-	 * @return DataResponse<Http::STATUS_OK|Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array{message: string, nid: int}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
 	 *
 	 * 200: Test notification generated successfully, but the device should still show the message to the user
 	 * 400: Test notification could not be generated, show the message to the user
@@ -208,6 +208,10 @@ class APIController extends OCSController {
 
 			$this->notificationApp->setOutput($output);
 			$this->notificationManager->notify($notification);
+
+			/** @var int $nid */
+			$nid = $this->notificationApp->getLastInsertedId();
+			return new DataResponse(['message' => $output->fetch(), 'nid' => $nid]);
 		} catch (\InvalidArgumentException $e) {
 			$this->logger->error('Self testing push notification failed: ' . $e->getMessage(), ['exception' => $e]);
 			return new DataResponse(
@@ -215,7 +219,5 @@ class APIController extends OCSController {
 				Http::STATUS_BAD_REQUEST,
 			);
 		}
-
-		return new DataResponse(['message' => $output->fetch()]);
 	}
 }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1514,11 +1514,16 @@
                                                 "data": {
                                                     "type": "object",
                                                     "required": [
-                                                        "message"
+                                                        "message",
+                                                        "nid"
                                                     ],
                                                     "properties": {
                                                         "message": {
                                                             "type": "string"
+                                                        },
+                                                        "nid": {
+                                                            "type": "integer",
+                                                            "format": "int64"
                                                         }
                                                     }
                                                 }

--- a/openapi-push.json
+++ b/openapi-push.json
@@ -163,11 +163,16 @@
                                                 "data": {
                                                     "type": "object",
                                                     "required": [
-                                                        "message"
+                                                        "message",
+                                                        "nid"
                                                     ],
                                                     "properties": {
                                                         "message": {
                                                             "type": "string"
+                                                        },
+                                                        "nid": {
+                                                            "type": "integer",
+                                                            "format": "int64"
                                                         }
                                                     }
                                                 }


### PR DESCRIPTION
For clients to do automatic verification that the push test worked it is necessary to know which notification is expected.
Then they can also hide this special notification from the user since it's not really useful for them.