### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "98066cc64792811ceaf962eacab239f7a3bfaacc"
+                "reference": "f24b0b50b127b0a6d412f1be7175825832d146ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/98066cc64792811ceaf962eacab239f7a3bfaacc",
-                "reference": "98066cc64792811ceaf962eacab239f7a3bfaacc",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f24b0b50b127b0a6d412f1be7175825832d146ce",
+                "reference": "f24b0b50b127b0a6d412f1be7175825832d146ce",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-06-21T00:52:23+00:00"
+            "time": "2025-07-01T15:03:36+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency