### PR TITLE
[stable32] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "24499e45276ec7b157b14e9c09023fab4edd38cd"
+                "reference": "fc0f7a56ddd9a6278f2aa5a4c3c050d6f70928db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/24499e45276ec7b157b14e9c09023fab4edd38cd",
-                "reference": "24499e45276ec7b157b14e9c09023fab4edd38cd",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/fc0f7a56ddd9a6278f2aa5a4c3c050d6f70928db",
+                "reference": "fc0f7a56ddd9a6278f2aa5a4c3c050d6f70928db",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2025-09-05T00:47:21+00:00"
+            "time": "2025-09-06T00:45:35+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency