### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "71cd0e748626ebf63e5f4614bc8745a3e69e615b"
+                "reference": "8defbc880561a94780890bc3c2e13e5caf0844dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/71cd0e748626ebf63e5f4614bc8745a3e69e615b",
-                "reference": "71cd0e748626ebf63e5f4614bc8745a3e69e615b",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8defbc880561a94780890bc3c2e13e5caf0844dd",
+                "reference": "8defbc880561a94780890bc3c2e13e5caf0844dd",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-09-16T00:45:42+00:00"
+            "time": "2025-10-02T00:46:24+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency