### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "4a55dcdbff0ae2062a8e3cdb905fc4d6076240b9"
+                "reference": "a6ce31b62ba2bbe5f5862a6ce1e25c4333cc2eca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/4a55dcdbff0ae2062a8e3cdb905fc4d6076240b9",
-                "reference": "4a55dcdbff0ae2062a8e3cdb905fc4d6076240b9",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a6ce31b62ba2bbe5f5862a6ce1e25c4333cc2eca",
+                "reference": "a6ce31b62ba2bbe5f5862a6ce1e25c4333cc2eca",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-10-03T00:46:19+00:00"
+            "time": "2025-10-07T00:47:13+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency