### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "45897bf3341b6fb4952edde83d9dddfd9e4f6977"
+                "reference": "74cba70aa359651b390ea51bc487cfa0d7cf0c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/45897bf3341b6fb4952edde83d9dddfd9e4f6977",
-                "reference": "45897bf3341b6fb4952edde83d9dddfd9e4f6977",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/74cba70aa359651b390ea51bc487cfa0d7cf0c9e",
+                "reference": "74cba70aa359651b390ea51bc487cfa0d7cf0c9e",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-11-07T00:51:51+00:00"
+            "time": "2025-11-12T00:52:34+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency