### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "59f2eb798ca7c3a0612436c2d9b576aae1475722"
+                "reference": "a1d4a0fed05683440b82e2551ce3a6c5d29aae45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/59f2eb798ca7c3a0612436c2d9b576aae1475722",
-                "reference": "59f2eb798ca7c3a0612436c2d9b576aae1475722",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a1d4a0fed05683440b82e2551ce3a6c5d29aae45",
+                "reference": "a1d4a0fed05683440b82e2551ce3a6c5d29aae45",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2026-01-09T00:57:53+00:00"
+            "time": "2026-01-20T00:56:22+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency