### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b8e5ee82481ddda93f5a7626f36c4d4c1bec16ea"
+                "reference": "be15a072d5f5694bf66311df85a1616596c74350"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b8e5ee82481ddda93f5a7626f36c4d4c1bec16ea",
-                "reference": "b8e5ee82481ddda93f5a7626f36c4d4c1bec16ea",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/be15a072d5f5694bf66311df85a1616596c74350",
+                "reference": "be15a072d5f5694bf66311df85a1616596c74350",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-02-06T01:05:40+00:00"
+            "time": "2026-02-11T01:18:39+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency