### PR TITLE
feat: Add periodical job to clean outdated notifications

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -39,6 +39,7 @@
 	</dependencies>
 
 	<background-jobs>
+		<job>OCA\Notifications\BackgroundJob\CleanupOutdatedNotifications</job>
 		<job>OCA\Notifications\BackgroundJob\GenerateUserSettings</job>
 		<job>OCA\Notifications\BackgroundJob\SendNotificationMails</job>
 	</background-jobs>

--- a/lib/BackgroundJob/CleanupOutdatedNotifications.php
+++ b/lib/BackgroundJob/CleanupOutdatedNotifications.php
@@ -10,6 +10,7 @@ namespace OCA\Notifications\BackgroundJob;
 
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\DB\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
@@ -53,66 +54,17 @@ class CleanupOutdatedNotifications extends TimedJob {
 	}
 
 	private function cleanupExcessNotifications(int $limit): int {
-		$usersWithExcessNotifications = $this->getUsersWithExcessNotifications($limit);
+		$qb = $this->db->getQueryBuilder();
 
-		$deleted = 0;
-		foreach ($usersWithExcessNotifications as $user) {
-			$thresholdId = $this->getThresholdNotificationId($user, $limit);
-
-			if ($thresholdId === null) {
-				continue;
-			}
-
-			$qb = $this->db->getQueryBuilder();
-			$deleted += $qb->delete('notifications')
-				->where($qb->expr()->eq('user', $qb->createNamedParameter($user)))
-				->andWhere(
-					$qb->expr()->lt('notification_id', $qb->createNamedParameter($thresholdId)),
+		return $qb->delete('notifications', 'n')
+			->where(
+				$qb->expr()->gte(
+					$qb->createFunction(
+						'(SELECT COUNT(*) FROM notifications n2 WHERE n2.user = n.user AND n2.notification_id > n.notification_id)'
+					),
+					$qb->createNamedParameter($limit, IQueryBuilder::PARAM_INT)
 				)
-				->executeStatement();
-		}
-
-		return $deleted;
-	}
-
-	/**
-	 * @return string[]
-	 */
-	private function getUsersWithExcessNotifications(int $limit): array {
-		$qb = $this->db->getQueryBuilder();
-
-		return $qb
-			->select('user')
-			->from('notifications')
-			->groupBy('user')
-			->having(
-				$qb->expr()->gt(
-					$qb->func()->count(),
-					$qb->createNamedParameter($limit),
-				),
 			)
-			->setMaxResults(1000)
-			->executeQuery()
-			->fetchAll(\PDO::FETCH_COLUMN);
-	}
-
-	/**
-	 * Returns the notification_id at position LIMIT_BY_COUNT_PER_USER (ordered DESC)
-	 * All notifications with ID less than this threshold will be deleted
-	 */
-	private function getThresholdNotificationId(string $user, int $limit): ?int {
-		$qb = $this->db->getQueryBuilder();
-
-		$result = $qb
-			->select('notification_id')
-			->from('notifications')
-			->where($qb->expr()->eq('user', $qb->createNamedParameter($user)))
-			->orderBy('notification_id', 'DESC')
-			->setFirstResult($limit)
-			->setMaxResults(1)
-			->executeQuery()
-			->fetchOne();
-
-		return $result !== false ? (int)$result : null;
+			->executeStatement();
 	}
 }

--- a/lib/BackgroundJob/CleanupOutdatedNotifications.php
+++ b/lib/BackgroundJob/CleanupOutdatedNotifications.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Notifications\BackgroundJob;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
+
+class CleanupOutdatedNotifications extends TimedJob {
+	public function __construct(
+		ITimeFactory $time,
+		private IConfig $config,
+		private LoggerInterface $logger,
+		private IDBConnection $db,
+	) {
+		parent::__construct($time);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+		$this->setInterval(24 * 60 * 60);
+	}
+
+	#[\Override]
+	protected function run($argument): void {
+		// Remove notifications that are older than one year
+		$expireDays = $this->config->getSystemValue('notifications_expire_days', 365);
+		$count = $this->cleanupOldNotifications($expireDays);
+		$this->logger->info('Cleaned up ' . $count . ' notifications that are older than ' . $expireDays . ' days',
+			['count' => $count]);
+
+		// Remove notifications from users that have more than the limit
+		$excessLimit = $this->config->getSystemValue('notifications_excess_limit', 10_000);
+		$count = $this->cleanupExcessNotifications($excessLimit);
+		$this->logger->info('Cleaned up ' . $count . ' notifications from users that excess ' . $excessLimit . ' notifications',
+			['count' => $count]);
+	}
+
+	private function cleanupOldNotifications(int $expireDays): int {
+		$deleteFrom = $this->time->getDateTime('-' . $expireDays . ' days');
+		$qb = $this->db->getQueryBuilder();
+
+		return $qb->delete('notifications')
+			->where(
+				$qb->expr()->lt('timestamp', $qb->createNamedParameter($deleteFrom->getTimestamp())),
+			)
+			->executeStatement();
+	}
+
+	private function cleanupExcessNotifications(int $limit): int {
+		$usersWithExcessNotifications = $this->getUsersWithExcessNotifications($limit);
+
+		$deleted = 0;
+		foreach ($usersWithExcessNotifications as $user) {
+			$thresholdId = $this->getThresholdNotificationId($user, $limit);
+
+			if ($thresholdId === null) {
+				continue;
+			}
+
+			$qb = $this->db->getQueryBuilder();
+			$deleted += $qb->delete('notifications')
+				->where($qb->expr()->eq('user', $qb->createNamedParameter($user)))
+				->andWhere(
+					$qb->expr()->lt('notification_id', $qb->createNamedParameter($thresholdId)),
+				)
+				->executeStatement();
+		}
+
+		return $deleted;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function getUsersWithExcessNotifications(int $limit): array {
+		$qb = $this->db->getQueryBuilder();
+
+		return $qb
+			->select('user')
+			->from('notifications')
+			->groupBy('user')
+			->having(
+				$qb->expr()->gt(
+					$qb->func()->count(),
+					$qb->createNamedParameter($limit),
+				),
+			)
+			->setMaxResults(1000)
+			->executeQuery()
+			->fetchAll(\PDO::FETCH_COLUMN);
+	}
+
+	/**
+	 * Returns the notification_id at position LIMIT_BY_COUNT_PER_USER (ordered DESC)
+	 * All notifications with ID less than this threshold will be deleted
+	 */
+	private function getThresholdNotificationId(string $user, int $limit): ?int {
+		$qb = $this->db->getQueryBuilder();
+
+		$result = $qb
+			->select('notification_id')
+			->from('notifications')
+			->where($qb->expr()->eq('user', $qb->createNamedParameter($user)))
+			->orderBy('notification_id', 'DESC')
+			->setFirstResult($limit)
+			->setMaxResults(1)
+			->executeQuery()
+			->fetchOne();
+
+		return $result !== false ? (int)$result : null;
+	}
+}


### PR DESCRIPTION
In our organization we have too many notificatons and this slowdowns app, increase db size, etc.

This PR adds possibility to cleanup outdated notifications that met next criteria:
- notification was created more than 365 days ago. Configurable via `notifications_expire_days` system parameter
- user has more than 10 000 notifications. Configurable via `notifications_excess_limit` system parameter