### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "be15a072d5f5694bf66311df85a1616596c74350"
+                "reference": "cdb5232c76c7046ad44b6f8f123c8af160f6529f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/be15a072d5f5694bf66311df85a1616596c74350",
-                "reference": "be15a072d5f5694bf66311df85a1616596c74350",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/cdb5232c76c7046ad44b6f8f123c8af160f6529f",
+                "reference": "cdb5232c76c7046ad44b6f8f123c8af160f6529f",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-02-11T01:18:39+00:00"
+            "time": "2026-04-08T01:20:30+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency