### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b92d626c25f78bf12a20d187c274e17a75fa598f"
+                "reference": "384c4832180988e2dc6acb444a732074275253f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b92d626c25f78bf12a20d187c274e17a75fa598f",
-                "reference": "b92d626c25f78bf12a20d187c274e17a75fa598f",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/384c4832180988e2dc6acb444a732074275253f6",
+                "reference": "384c4832180988e2dc6acb444a732074275253f6",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-04-14T01:25:24+00:00"
+            "time": "2026-04-16T01:27:31+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency