### PR TITLE
feat(ui): Do Not Disturb toggle and while-DND summary banner

### DIFF
--- a/src/NotificationsApp.vue
+++ b/src/NotificationsApp.vue
@@ -15,12 +15,34 @@
 		<template #trigger>
 			<IconNotification
 				:size="20"
-				:showDot="notifications.length !== 0 || webNotificationsGranted === null"
+				:showDot="!isDnd && (notifications.length !== 0 || webNotificationsGranted === null)"
 				:showWarning="hasThrottledPushNotifications" />
 		</template>
 
 		<!-- Notifications list content -->
 		<div class="notification-container">
+			<!-- Panel header with Do Not Disturb toggle -->
+			<div class="notification-panel-header">
+				<span class="notification-panel-title">{{ t('notifications', 'Notifications') }}</span>
+				<NcButton
+					variant="tertiary"
+					:class="{ 'dnd-active': isDnd }"
+					:title="isDnd ? t('notifications', 'Disable Do Not Disturb') : t('notifications', 'Enable Do Not Disturb')"
+					:aria-label="isDnd ? t('notifications', 'Disable Do Not Disturb') : t('notifications', 'Enable Do Not Disturb')"
+					@click="toggleDnd">
+					<template #icon>
+						<IconBellOff :size="18" />
+					</template>
+				</NcButton>
+			</div>
+			<!-- "New while DND" banner -->
+			<div v-if="dndBanner > 0" class="notification-dnd-banner">
+				<span>{{ dndBannerText }}</span>
+				<NcButton variant="tertiary" @click="dndBanner = 0">
+					<template #icon><IconClose :size="16" /></template>
+				</NcButton>
+			</div>
+
 			<transition name="fade" mode="out-in">
 				<transition-group
 					v-if="notifications.length > 0"
@@ -92,6 +114,7 @@ import { generateOcsUrl, imagePath } from '@nextcloud/router'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import NcHeaderMenu from '@nextcloud/vue/components/NcHeaderMenu'
+import IconBellOff from 'vue-material-design-icons/BellOff.vue'
 import IconBellOutline from 'vue-material-design-icons/BellOutline.vue'
 import IconClose from 'vue-material-design-icons/Close.vue'
 import IconMessageOutline from 'vue-material-design-icons/MessageOutline.vue'
@@ -131,6 +154,7 @@ export default {
 	name: 'NotificationsApp',
 
 	components: {
+		IconBellOff,
 		IconBellOutline,
 		IconClose,
 		IconMessageOutline,
@@ -187,6 +211,11 @@ export default {
 			pushEndpoints: null,
 
 			open: false,
+
+			/** Whether Do Not Disturb is enabled locally (suppresses dot, sounds, browser notifications) */
+			isDnd: JSON.parse(localStorage.getItem('notifications:dnd') ?? 'false'),
+			/** Count of notifications that arrived while DND was on (> 0 shows banner) */
+			dndBanner: 0,
 		}
 	},
 
@@ -195,7 +224,15 @@ export default {
 			return this.backgroundFetching
 				&& this.webNotificationsGranted
 				&& this.userStatus !== 'dnd'
+				&& !this.isDnd
 				&& this.tabId === this.lastTabId
+		},
+
+		dndBannerText() {
+			const c = this.dndBanner
+			return c === 1
+				? t('notifications', '1 new notification received while in Do Not Disturb')
+				: t('notifications', '{count} new notifications received while in Do Not Disturb', { count: c })
 		},
 
 		emptyContentMessage() {
@@ -345,6 +382,19 @@ export default {
 		onRemove(index) {
 			this.notifications.splice(index, 1)
 			setCurrentTabAsActive(this.tabId)
+		},
+
+		toggleDnd() {
+			if (!this.isDnd) {
+				// Turning ON: snapshot current max ID so we can count new arrivals on re-enable
+				this._dndMaxIdAtEnable = this.notifications.reduce((max, n) => Math.max(max, n.notificationId), 0)
+			} else {
+				// Turning OFF: surface a banner for any notifications that arrived while DND was active
+				const newCount = this.notifications.filter(n => n.notificationId > (this._dndMaxIdAtEnable || 0)).length
+				if (newCount > 0) this.dndBanner = newCount
+			}
+			this.isDnd = !this.isDnd
+			localStorage.setItem('notifications:dnd', JSON.stringify(this.isDnd))
 		},
 
 		/**

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -123,3 +123,34 @@ svg {
 		}
 	}
 }
+
+// Panel header with the Do Not Disturb toggle
+.notification-panel-header {
+	display: flex;
+	align-items: center;
+	padding: 2px 4px 2px 16px;
+	border-bottom: 1px solid var(--color-border);
+
+	.notification-panel-title {
+		flex: 1;
+		font-size: 13px;
+		font-weight: 600;
+		color: var(--color-text-maxcontrast);
+	}
+
+	.dnd-active {
+		color: var(--color-error) !important;
+	}
+}
+
+// "New while DND" summary banner shown after disabling DND
+.notification-dnd-banner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 4px 4px 4px 16px;
+	border-bottom: 1px solid var(--color-border);
+	background: color-mix(in srgb, var(--color-warning) 10%, var(--color-main-background));
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}


### PR DESCRIPTION
Adds a quick Do Not Disturb toggle to the top of the notification panel. While DND is on, the bell dot indicator is suppressed and browser notifications are not raised. The state is persisted in localStorage so it survives reloads.

When DND is turned back off, a one-shot banner reports how many new notifications arrived during the DND window so they aren't silently missed.

* NotificationsApp.vue: panel header with toggle, banner, isDnd data, toggleDnd method, dndBannerText computed, showBrowserNotifications now honors isDnd
* styles.scss: panel header and warning-tinted banner

Note: this PR only suppresses the dot indicator, not a numeric count badge — the count badge ships in a separate PR. Once both are merged, DND should also zero the badge count.