### PR TITLE
feat(ui): numeric count badge replaces dot indicator

### DIFF
--- a/src/Components/IconNotification.vue
+++ b/src/Components/IconNotification.vue
@@ -4,9 +4,10 @@
 -->
 
 <template>
-	<span v-if="showDot || showWarning" class="notifications-button__icon">
-		<!-- Modified IconBell from material design icons -->
+	<span class="notifications-button__icon">
+		<!-- Bell with SVG dot: warning state or pending-permission state (showDot but no count) -->
 		<svg
+			v-if="showWarning || (showDot && count === 0)"
 			xmlns="http://www.w3.org/2000/svg"
 			xmlns:xlink="http://www.w3.org/1999/xlink"
 			version="1.1"
@@ -23,8 +24,17 @@
 				}"
 				d="M 21,6.5 C 21,8.43 19.43,10 17.5,10 15.57,10 14,8.43 14,6.5 14,4.57 15.57,3 17.5,3 19.43,3 21,4.57 21,6.5" />
 		</svg>
+		<!-- Plain bell for all other states (count badge handles the indicator) -->
+		<IconBell v-else :size="size" />
+		<!-- Numeric count badge (replaces the dot when there are real notifications) -->
+		<span
+			v-if="count > 0 && !showWarning"
+			:key="count"
+			class="notification__badge"
+			aria-hidden="true">
+			{{ count > 99 ? '99+' : count }}
+		</span>
 	</span>
-	<IconBell v-else class="notifications-button__icon" :size="size" />
 </template>
 
 <script setup>
@@ -40,6 +50,10 @@ defineProps({
 	showWarning: {
 		type: Boolean,
 		default: false,
+	},
+	count: {
+		type: Number,
+		default: 0,
 	},
 	size: {
 		type: Number,

--- a/src/NotificationsApp.vue
+++ b/src/NotificationsApp.vue
@@ -15,6 +15,7 @@
 		<template #trigger>
 			<IconNotification
 				:size="20"
+				:count="notifications.length"
 				:showDot="notifications.length !== 0 || webNotificationsGranted === null"
 				:showWarning="hasThrottledPushNotifications" />
 		</template>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -5,6 +5,8 @@
 
 .notifications-button {
 	.notifications-button__icon {
+		position: relative;
+		display: inline-flex;
 		height: 20px;
 	}
 
@@ -16,6 +18,33 @@
 		&--white {
 			fill: var(--color-primary-text);
 		}
+	}
+
+	// Numeric count badge — replaces the dot when count > 0
+	.notification__badge {
+		position: absolute;
+		top: -5px;
+		inset-inline-end: -8px;
+		min-width: 16px;
+		height: 16px;
+		padding: 0 3px;
+		border-radius: 8px;
+		background: #ff4402;
+		color: #fff;
+		font-size: 9px;
+		font-weight: 700;
+		line-height: 16px;
+		text-align: center;
+		pointer-events: none;
+		box-sizing: border-box;
+		// :key="count" forces remount on every change → animation re-fires automatically
+		animation: badge-pop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+	}
+
+	@keyframes badge-pop {
+		0% { transform: scale(0.5); }
+		70% { transform: scale(1.35); }
+		100% { transform: scale(1); }
 	}
 
 	&.hasNotifications {


### PR DESCRIPTION
The bell icon now shows a numeric badge (capped at "99+") when there are notifications, instead of the previous solid dot. The dot is kept for the warning and pending-permission states. The badge re-keys on every count change so the pop animation re-fires whenever a new notification arrives.

* IconNotification.vue: count prop with default 0; renders the dot SVG only when warning or pending-permission, the plain bell + badge otherwise
* NotificationsApp.vue: passes notifications.length as :count
* styles.scss: badge styling and badge-pop keyframe