### PR TITLE
[stable34] Update nextcloud/ocp dependency

### DIFF
--- a/vendor-bin/nextcloud-ocp/composer.json
+++ b/vendor-bin/nextcloud-ocp/composer.json
@@ -1,5 +1,5 @@
 {
     "require-dev": {
-        "nextcloud/ocp": "dev-master"
+        "nextcloud/ocp": "dev-stable34"
     }
 }

--- a/vendor-bin/nextcloud-ocp/composer.lock
+++ b/vendor-bin/nextcloud-ocp/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5dbd6ae6465ad99765e7d232c3bba5b1",
+    "content-hash": "6d8d2d5dafd09ef47b9d253d0014ed4f",
     "packages": [],
     "packages-dev": [
         {
             "name": "nextcloud/ocp",
-            "version": "dev-master",
+            "version": "dev-stable34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5e28edd0c8a49c7a1941941108f514e1aec027ac"
+                "reference": "72de02fbad95545055983d050e564fe39128992d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5e28edd0c8a49c7a1941941108f514e1aec027ac",
-                "reference": "5e28edd0c8a49c7a1941941108f514e1aec027ac",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/72de02fbad95545055983d050e564fe39128992d",
+                "reference": "72de02fbad95545055983d050e564fe39128992d",
                 "shasum": ""
             },
             "require": {
@@ -29,11 +29,10 @@
                 "psr/http-client": "^1.0.3",
                 "psr/log": "^3.0.2"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "34.0.0-dev"
+                    "dev-stable34": "34.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -53,9 +52,9 @@
             "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/master"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable34"
             },
-            "time": "2026-05-15T02:04:21+00:00"
+            "time": "2026-05-15T08:43:27+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency