### PR TITLE
fix(webpush): recover gracefully from corrupted or mismatched VAPID keys

### DIFF
--- a/lib/WebPushClient.php
+++ b/lib/WebPushClient.php
@@ -66,8 +66,14 @@ class WebPushClient {
 	 */
 	private function getVapid(): array {
 		// Do not use lazy for now
-		$publicKey = $this->appConfig->getAppValueString('webpush_vapid_pubkey');
-		$privateKey = $this->appConfig->getAppValueString('webpush_vapid_privkey');
+		try {
+			$publicKey = $this->appConfig->getAppValueString('webpush_vapid_pubkey');
+			$privateKey = $this->appConfig->getAppValueString('webpush_vapid_privkey');
+		} catch (\Throwable) {
+			// Decryption failed (e.g. mismatched instance secret), regenerate keys
+			$publicKey = '';
+			$privateKey = '';
+		}
 		if ($publicKey === '' || $privateKey === '') {
 			/** @var array{publicKey: string, privateKey: string} $vapid */
 			$vapid = VAPID::createVapidKeys();

--- a/tests/Unit/WebPushClientTest.php
+++ b/tests/Unit/WebPushClientTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Notifications\Tests\Unit;
+
+use OCA\Notifications\WebPushClient;
+use OCP\AppFramework\Services\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class WebPushClientTest extends TestCase {
+	protected IAppConfig&MockObject $appConfig;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->appConfig = $this->createMock(IAppConfig::class);
+	}
+
+	public function testConstructSucceedsWhenVapidKeysAreStored(): void {
+		$this->appConfig->method('getAppValueString')
+			->willReturnMap([
+				['webpush_vapid_pubkey', '', false, 'BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw'],
+				['webpush_vapid_privkey', '', false, 'test-private-key'],
+			]);
+
+		$this->appConfig->expects($this->never())->method('setAppValueString');
+
+		$client = new WebPushClient($this->appConfig);
+		$this->assertInstanceOf(WebPushClient::class, $client);
+	}
+
+	public function testConstructRegeneratesVapidKeysWhenDecryptionFails(): void {
+		// Simulates the case where the stored VAPID keys were encrypted with a
+		// different instance secret — getAppValueString throws during decryption.
+		$this->appConfig->method('getAppValueString')
+			->willThrowException(new \RuntimeException('HMAC does not match.'));
+
+		$this->appConfig->expects($this->exactly(2))
+			->method('setAppValueString')
+			->with($this->logicalOr(
+				$this->equalTo('webpush_vapid_pubkey'),
+				$this->equalTo('webpush_vapid_privkey'),
+			));
+
+		// Must not throw — corrupted keys should be transparently regenerated
+		$client = new WebPushClient($this->appConfig);
+		$this->assertInstanceOf(WebPushClient::class, $client);
+	}
+
+	public function testConstructRegeneratesVapidKeysWhenMissing(): void {
+		$this->appConfig->method('getAppValueString')
+			->willReturnMap([
+				['webpush_vapid_pubkey', '', false, ''],
+				['webpush_vapid_privkey', '', false, ''],
+			]);
+
+		$this->appConfig->expects($this->exactly(2))
+			->method('setAppValueString')
+			->with($this->logicalOr(
+				$this->equalTo('webpush_vapid_pubkey'),
+				$this->equalTo('webpush_vapid_privkey'),
+			));
+
+		$client = new WebPushClient($this->appConfig);
+		$this->assertInstanceOf(WebPushClient::class, $client);
+	}
+}


### PR DESCRIPTION
## Summary

Companion PR to https://github.com/nextcloud/server/pull/60735

- If VAPID keys stored in `app_config` were encrypted with a different instance secret (e.g. after a migration or secret rotation), `getAppValueString()` throws during decryption
- This caused `WebPushClient::__construct()` to crash, which in turn crashed unrelated requests — e.g. joining a Talk room, which triggers notification processing as a side effect
- Fix: catch any `\Throwable` from `getAppValueString()` in `getVapid()` and treat it the same as missing keys, regenerating a fresh VAPID key pair stored with the current secret

The immediate workaround for affected instances is:
```
occ config:app:delete notifications webpush_vapid_pubkey
occ config:app:delete notifications webpush_vapid_privkey
```
This fix makes the app self-heal that state transparently.

## Test plan

- [x] `NOCOVERAGE=1 ./autotest.sh sqlite apps-extra/notifications/tests/Unit/WebPushClientTest.php`
- [x] New `WebPushClientTest` covers three cases: valid stored keys, missing keys, and keys that throw on decryption

🤖 Generated with [Claude Code](https://claude.com/claude-code)