### PR TITLE
[stable33] fix: Add missing DI for IAppConfig to Push.php

### DIFF
--- a/lib/Push.php
+++ b/lib/Push.php
@@ -16,6 +16,7 @@ use OC\Security\IdentityProof\Key;
 use OC\Security\IdentityProof\Manager;
 use OCA\Notifications\AppInfo\Application;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\Token\IToken;
@@ -78,6 +79,7 @@ class Push {
 		protected IDBConnection $db,
 		protected INotificationManager $notificationManager,
 		protected IConfig $config,
+		protected IAppConfig $appConfig,
 		protected IProvider $tokenProvider,
 		protected Manager $keyManager,
 		protected IClientService $clientService,

--- a/tests/Unit/PushTest.php
+++ b/tests/Unit/PushTest.php
@@ -17,6 +17,7 @@ use OC\Security\IdentityProof\Key;
 use OC\Security\IdentityProof\Manager;
 use OCA\Notifications\Push;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\Token\IToken as OCPIToken;
 use OCP\Http\Client\IClient;
@@ -48,6 +49,7 @@ class PushTest extends TestCase {
 	protected IDBConnection $db;
 	protected INotificationManager&MockObject $notificationManager;
 	protected IConfig&MockObject $config;
+	protected IAppConfig&MockObject $appConfig;
 	protected IProvider&MockObject $tokenProvider;
 	protected Manager&MockObject $keyManager;
 	protected IClientService&MockObject $clientService;
@@ -65,6 +67,7 @@ class PushTest extends TestCase {
 		$this->db = \OCP\Server::get(IDBConnection::class);
 		$this->notificationManager = $this->createMock(INotificationManager::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->tokenProvider = $this->createMock(IProvider::class);
 		$this->keyManager = $this->createMock(Manager::class);
 		$this->clientService = $this->createMock(IClientService::class);
@@ -91,6 +94,7 @@ class PushTest extends TestCase {
 					$this->db,
 					$this->notificationManager,
 					$this->config,
+					$this->appConfig,
 					$this->tokenProvider,
 					$this->keyManager,
 					$this->clientService,
@@ -109,6 +113,7 @@ class PushTest extends TestCase {
 			$this->db,
 			$this->notificationManager,
 			$this->config,
+			$this->appConfig,
 			$this->tokenProvider,
 			$this->keyManager,
 			$this->clientService,


### PR DESCRIPTION
* Regression from https://github.com/nextcloud/notifications/pull/2986 / https://github.com/nextcloud/notifications/pull/2971