### PR TITLE
chore: extend testing of `encryptAndSign` and make the methods discoverable by psalm

### DIFF
--- a/lib/Push.php
+++ b/lib/Push.php
@@ -447,7 +447,7 @@ class Push {
 
 		$this->printInfo('');
 		$this->printInfo('Found ' . count($devices) . ' devices registered for push notifications');
-		$isTalkNotification = \in_array($notification->getApp(), ['spreed', 'talk', 'admin_notification_talk'], true);
+
 		$devices = $this->filterProxyDeviceList($devices, $notification->getApp());
 		if (empty($devices)) {
 			$this->printInfo('<comment>No devices left after filtering</comment>');
@@ -461,7 +461,7 @@ class Push {
 			$this->printInfo('Device token: ' . $device['token']);
 
 			try {
-				$payload = json_encode($this->encryptAndSign($userKey->getPrivate(), $device, $id, $notification, $isTalkNotification), JSON_THROW_ON_ERROR);
+				$payload = json_encode($this->encryptAndSign($userKey->getPrivate(), $device, $id, $notification), JSON_THROW_ON_ERROR);
 
 				$proxyServer = rtrim($device['proxyserver'], '/');
 				if (!isset($this->payloadsToSend[$proxyServer])) {
@@ -952,13 +952,12 @@ class Push {
 	 * @param array $device
 	 * @param int $id
 	 * @param INotification $notification
-	 * @param bool $isTalkNotification
 	 * @return array
 	 * @psalm-return array{deviceIdentifier: string, pushTokenHash: string, subject: string, signature: string, priority: string, type: string}
 	 * @throws InvalidTokenException
 	 * @throws \InvalidArgumentException
 	 */
-	protected function encryptAndSign(string $userPrivateKey, array $device, int $id, INotification $notification, bool $isTalkNotification): array {
+	protected function encryptAndSign(string $userPrivateKey, array $device, int $id, INotification $notification): array {
 		$data = $this->encodeNotif($id, $notification, 200);
 		$ret = $this->getNotifTopicAndUrgency($data['app'], $data['type']);
 		$priority = $ret['urgency'];

--- a/lib/Push.php
+++ b/lib/Push.php
@@ -461,7 +461,7 @@ class Push {
 			$this->printInfo('Device token: ' . $device['token']);
 
 			try {
-				$payload = json_encode($this->encryptAndSign($userKey, $device, $id, $notification, $isTalkNotification), JSON_THROW_ON_ERROR);
+				$payload = json_encode($this->encryptAndSign($userKey->getPrivate(), $device, $id, $notification, $isTalkNotification), JSON_THROW_ON_ERROR);
 
 				$proxyServer = rtrim($device['proxyserver'], '/');
 				if (!isset($this->payloadsToSend[$proxyServer])) {
@@ -629,7 +629,7 @@ class Push {
 				}
 
 				if ($deleteAll) {
-					$data = $this->encryptAndSignDelete($userKey, $device, null);
+					$data = $this->encryptAndSignDelete($userKey->getPrivate(), $device, null);
 					try {
 						$this->payloadsToSend[$proxyServer][] = json_encode($data['payload'], JSON_THROW_ON_ERROR);
 					} catch (\JsonException $e) {
@@ -640,7 +640,7 @@ class Push {
 					// use to not support `delete-multiple`
 					if (!\in_array($app, ['spreed', 'talk', 'admin_notification_talk'], true)) {
 						foreach ($notificationIds ?? [] as $notificationId) {
-							$data = $this->encryptAndSignDelete($userKey, $device, [$notificationId]);
+							$data = $this->encryptAndSignDelete($userKey->getPrivate(), $device, [$notificationId]);
 							try {
 								$this->payloadsToSend[$proxyServer][] = json_encode($data['payload'], JSON_THROW_ON_ERROR);
 							} catch (\JsonException $e) {
@@ -650,7 +650,7 @@ class Push {
 					} else {
 						$temp = $notificationIds;
 						while (!empty($temp)) {
-							$data = $this->encryptAndSignDelete($userKey, $device, $temp);
+							$data = $this->encryptAndSignDelete($userKey->getPrivate(), $device, $temp);
 							$temp = $data['remaining'];
 							try {
 								$this->payloadsToSend[$proxyServer][] = json_encode($data['payload'], JSON_THROW_ON_ERROR);
@@ -948,7 +948,7 @@ class Push {
 	}
 
 	/**
-	 * @param Key $userKey
+	 * @param string $userPrivateKey
 	 * @param array $device
 	 * @param int $id
 	 * @param INotification $notification
@@ -958,30 +958,32 @@ class Push {
 	 * @throws InvalidTokenException
 	 * @throws \InvalidArgumentException
 	 */
-	protected function encryptAndSign(Key $userKey, array $device, int $id, INotification $notification, bool $isTalkNotification): array {
+	protected function encryptAndSign(string $userPrivateKey, array $device, int $id, INotification $notification, bool $isTalkNotification): array {
 		$data = $this->encodeNotif($id, $notification, 200);
 		$ret = $this->getNotifTopicAndUrgency($data['app'], $data['type']);
 		$priority = $ret['urgency'];
 		$type = $ret['type'];
 
+		$jsonData = json_encode($data, JSON_THROW_ON_ERROR);
+
 		$this->printInfo('Device public key size: ' . strlen((string)$device['devicepublickey']));
-		$this->printInfo('Data to encrypt is: ' . json_encode($data));
+		$this->printInfo('Data to encrypt is: ' . $jsonData);
 
 		$padding = $this->appConfig->getAppValueString('push_encryption_padding', 'OAEP') === 'OAEP' ? OPENSSL_PKCS1_OAEP_PADDING : OPENSSL_PKCS1_PADDING;
-		if (!openssl_public_encrypt(json_encode($data), $encryptedSubject, $device['devicepublickey'], $padding)) {
-			$error = openssl_error_string();
+		if (!openssl_public_encrypt($jsonData, $encryptedSubject, $device['devicepublickey'], $padding)) {
+			$error = openssl_error_string() ?: 'Unknown OpenSSL error';
 			$this->log->error($error, ['app' => 'notifications']);
 			$this->printInfo('<error>Error while encrypting data: "' . $error . '"</error>');
 			throw new \InvalidArgumentException('Failed to encrypt message for device');
 		}
 
-		if (openssl_sign($encryptedSubject, $signature, $userKey->getPrivate(), OPENSSL_ALGO_SHA512)) {
+		if (openssl_sign($encryptedSubject, $signature, $userPrivateKey, OPENSSL_ALGO_SHA512)) {
 			$this->printInfo('Signed encrypted push subject');
 		} else {
 			$this->printInfo('<error>Failed to signed encrypted push subject</error>');
 		}
-		$base64EncryptedSubject = base64_encode((string)$encryptedSubject);
-		$base64Signature = base64_encode((string)$signature);
+		$base64EncryptedSubject = base64_encode($encryptedSubject);
+		$base64Signature = base64_encode($signature);
 
 		return [
 			'deviceIdentifier' => $device['deviceidentifier'],
@@ -994,28 +996,29 @@ class Push {
 	}
 
 	/**
-	 * @param Key $userKey
+	 * @param string $userPrivateKey
 	 * @param array $device
 	 * @param ?int[] $ids
 	 * @return array
-	 * @psalm-return array{remaining: list<int>, payload: array{deviceIdentifier: string, pushTokenHash: string, subject: string, signature: string, priority: string, type: string}}
+	 * @psalm-return array{remaining: array<array-key, int>, payload: array{deviceIdentifier: string, pushTokenHash: string, subject: string, signature: string, priority: string, type: string}}
 	 * @throws InvalidTokenException
 	 * @throws \InvalidArgumentException
 	 */
-	protected function encryptAndSignDelete(Key $userKey, array $device, ?array $ids): array {
+	protected function encryptAndSignDelete(string $userPrivateKey, array $device, ?array $ids): array {
 		$ret = $this->encodeDeleteNotifs($ids);
 		$remainingIds = $ret['remaining'];
 		$data = $ret['data'];
 
 		$padding = $this->appConfig->getAppValueString('push_encryption_padding', 'OAEP') === 'OAEP' ? OPENSSL_PKCS1_OAEP_PADDING : OPENSSL_PKCS1_PADDING;
-		if (!openssl_public_encrypt(json_encode($data), $encryptedSubject, $device['devicepublickey'], $padding)) {
-			$this->log->error(openssl_error_string(), ['app' => 'notifications']);
+		if (!openssl_public_encrypt(json_encode($data, JSON_THROW_ON_ERROR), $encryptedSubject, $device['devicepublickey'], $padding)) {
+			$error = openssl_error_string() ?: 'Unknown OpenSSL error';
+			$this->log->error($error, ['app' => 'notifications']);
 			throw new \InvalidArgumentException('Failed to encrypt message for device');
 		}
 
-		openssl_sign($encryptedSubject, $signature, $userKey->getPrivate(), OPENSSL_ALGO_SHA512);
-		$base64EncryptedSubject = base64_encode((string)$encryptedSubject);
-		$base64Signature = base64_encode((string)$signature);
+		openssl_sign($encryptedSubject, $signature, $userPrivateKey, OPENSSL_ALGO_SHA512);
+		$base64EncryptedSubject = base64_encode($encryptedSubject);
+		$base64Signature = base64_encode($signature);
 
 		return [
 			'remaining' => $remainingIds,

--- a/tests/Unit/PushTest.php
+++ b/tests/Unit/PushTest.php
@@ -553,7 +553,7 @@ FQIDAQAB
 			->method('getAppValueString')
 			->willReturnMap([
 				['subscription_aware_server', 'https://push-notifications.nextcloud.com', 'https://push-notifications.nextcloud.com'],
-				['push_encryption_padding', 'PKCS1', $padding],
+				['push_encryption_padding', 'OAEP', $padding],
 			]);
 
 		$this->globalAppConfig

--- a/tests/Unit/PushTest.php
+++ b/tests/Unit/PushTest.php
@@ -826,7 +826,7 @@ sd7MhWnjKf7EX9GJD0VhLabFY/KrloJkyL7gOY21xFvmnNqwvH60eOxbVPzlYjaN
 
 			$push->expects($this->exactly(1))
 				->method('encryptAndSign')
-				->with($this->anything(), $devices[$pushedDevice], $this->anything(), $this->anything(), $isTalkNotification)
+				->with($this->anything(), $devices[$pushedDevice], $this->anything(), $this->anything())
 				->willReturn(['Payload']);
 
 			/** @var IClient&MockObject $client */

--- a/tests/Unit/PushTest.php
+++ b/tests/Unit/PushTest.php
@@ -455,14 +455,16 @@ class PushTest extends TestCase {
 
 	public static function dataProxyPushToDeviceSending(): array {
 		return [
-			[true],
-			[false],
+			[true, 'PKCS1'],
+			[true, 'OAEP'],
+			[false, 'PKCS1'],
+			[false, 'OAEP'],
 		];
 	}
 
 	#[DataProvider(methodName: 'dataProxyPushToDeviceSending')]
-	public function testPushToDeviceSending(bool $isDebug): void {
-		$push = $this->getPush(['getProxyDevicesForUser', 'encryptAndSign', 'deleteProxyPushToken', 'filterByTokenAge', 'deleteProxyPushTokenByDeviceIdentifier']);
+	public function testPushToDeviceSending(bool $isDebug, string $padding): void {
+		$push = $this->getPush(['getProxyDevicesForUser', 'deleteProxyPushToken', 'filterByTokenAge', 'deleteProxyPushTokenByDeviceIdentifier']);
 
 		/** @var INotification&MockObject $notification */
 		$notification = $this->createMock(INotification::class);
@@ -478,6 +480,16 @@ class PushTest extends TestCase {
 			->with('valid')
 			->willReturn($user);
 
+		$devicePublicKey = '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1SN9sDJGNifnEv/y1UkP
+tggJA0xks5b0WN/Ida3GYK4Zy/ZWTa3wAknCerKkZC2rrFbcP55HA/oSp8fuUJC3
+q4b59znuhGoQtvvdAwUx6qSIPheAGs/gfMpNWO/bfH02oBu+98eTkxciuNKPxBFk
+wRdSSUxsHwkzCOw+er6oxriVSkc7tsNVaXg+ZpzW15cUQugjT6JDDjg5ftSeGsLj
+VV70QXge4uD3ege/lsa1N8iUVCjeMJHobyQm/hhGE990b6BzTgOIC1pGsOPbOsZB
+/5n54G4EUX9dixSSF90fDJs83GWQ+AIjf/uHmj3vFMe1bnqIwq9P17+IWe5x9Z04
+FQIDAQAB
+-----END PUBLIC KEY-----';
+
 		$push->expects($this->once())
 			->method('getProxyDevicesForUser')
 			->willReturn([
@@ -485,31 +497,49 @@ class PushTest extends TestCase {
 					'proxyserver' => 'proxyserver1',
 					'token' => 16,
 					'apptype' => 'other',
+					'devicepublickey' => $devicePublicKey,
+					'deviceidentifier' => 'ident16',
+					'pushtokenhash' => 'hash16',
 				],
 				[
 					'proxyserver' => 'proxyserver1/',
 					'token' => 23,
 					'apptype' => 'other',
+					'devicepublickey' => $devicePublicKey,
+					'deviceidentifier' => 'ident23',
+					'pushtokenhash' => 'hash23',
 				],
 				[
 					'proxyserver' => 'badrequest',
 					'token' => 42,
 					'apptype' => 'other',
+					'devicepublickey' => $devicePublicKey,
+					'deviceidentifier' => 'ident42',
+					'pushtokenhash' => 'hash42',
 				],
 				[
 					'proxyserver' => 'unavailable',
 					'token' => 48,
 					'apptype' => 'other',
+					'devicepublickey' => $devicePublicKey,
+					'deviceidentifier' => 'ident48',
+					'pushtokenhash' => 'hash48',
 				],
 				[
 					'proxyserver' => 'ok',
 					'token' => 64,
 					'apptype' => 'other',
+					'devicepublickey' => $devicePublicKey,
+					'deviceidentifier' => 'ident64',
+					'pushtokenhash' => 'hash64',
 				],
 				[
 					'proxyserver' => 'badrequest-with-devices',
 					'token' => 128,
 					'apptype' => 'other',
+					'devicepublickey' => $devicePublicKey,
+					'deviceidentifier' => 'ident128',
+					'pushtokenhash' => 'hash128',
 				],
 			]);
 
@@ -519,9 +549,12 @@ class PushTest extends TestCase {
 			->willReturn($isDebug);
 
 		$this->appConfig
+			->expects($this->exactly(7))
 			->method('getAppValueString')
-			->with('subscription_aware_server', 'https://push-notifications.nextcloud.com')
-			->willReturn('https://push-notifications.nextcloud.com');
+			->willReturnMap([
+				['subscription_aware_server', 'https://push-notifications.nextcloud.com', 'https://push-notifications.nextcloud.com'],
+				['push_encryption_padding', 'PKCS1', $padding],
+			]);
 
 		$this->globalAppConfig
 			->method('getValueString')
@@ -541,6 +574,36 @@ class PushTest extends TestCase {
 		/** @var Key&MockObject $key */
 		$key = $this->createMock(Key::class);
 
+		$key->method('getPrivate')
+			->willReturn('-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCkGi7rj6BWi9U8
+lptb1rBKVFENFJjq690Ap8wAdR9cxGYE+nzdFxlcRxh17GwyWaBDEPWtL5WDPxi0
+8XjQWpwfYFzjMLLzGMZaj7Jiam5rJM12qFEvYyw9s26LzebeLTzvp28L2TIWCswi
+dM0OvrYGGvL9f+N+6Oev5cwiSJk0WrHceL+P/wFH3mmOdOBHmKkofeDZoS1XkNOE
+o1EpwepvDibUjc3vHPk1IHg4hsfKk1O9+uHiBf9xqm//M9MKrM9mlOButbo2bOhu
+1YN/2wKww7bU/c7JYgVeljpfN0sMuKmhMiuje2KqOU8v8yIREkKMyxd4+B+s3eNG
+PdVBf57FAgMBAAECggEAAMegdOm3xPyXMk+f0yNlh5kzDKE1itCL4aYIA6LZnLmp
+bHHJWZI4kTT1IHPdgDeYlPBjgAOuEFEsjhLySoXwoF4BIIgErCKD9xa9pBIojmVm
+LovlNfFlvScDKgsjUed+5ZguDLcYO7gyQvqTzS6ivXzq6TezeVDfeUgBTg3JG6n/
+BjgIek1jV4q9OrQTOdR3eAPwW6pbLG820OB87Cx/A0JHdEgCevFCHmMUbk7yXQrh
+W/JwTrnV66LBPjSWQcsHUNWrl2nqV08BYoC1uy32uTpUlejCdWDuHuB1DYOpn0KY
+nyiVTNF/MZ0E9sOsKKgbodBz4n3cc6v7NckpFpKMHwKBgQDUeaakKYwatNg6YEHP
+OB3iH62bAe7Ej6vg0EPYgr6fzRjAETzTrpZZfzmrGwTxFBczFrx8hOPsyDkpiEU5
+77L90jMOb9NSasjS8Pv0GM2LY/8H8Ck4RwXF/E3maSbc2bAY9ZXH6m82YW6iHnfc
+G9L0xVCq549axd1tWUnXdukiuwKBgQDFt9KDtlwMutuQOj+Eup7L0sMAxO4jlghH
+hTxSAqQ5mlodbQhULXRk4QWGMjjKG0y4XY2rw+VgBQzFT8W3jlThR3BMWKNv3P+M
+zlzkoxcoOio7K25im4Yb0NheOnaxaqhLcRwXcxa5E9kn+108xYIYAACZgmkZo7ab
+PCoQicnsfwKBgAzyEIYmBeRGqnn8DWZru95gIbq1BnAxdL5w0gFqDeU8oMprAnK/
+S2fOiZv0PHvXxoYVV4yaqCxwEpOGOvmJsjUmzneNtqlp2iyIBEHeFP/uKsa4Cjrk
+kOR8N97W/0grd0A+Dk8s6HO+wffctV7SzyqcrwqKq0BTl+cmrooTM6crAoGATjjT
+iFh1QnQKuZzR1GkgufLAQ2Wl8V5CGEmV+7wfzMpMLKgeS29QRTjhPp5P6WWzjJ02
+l2YBMWPOEaHlzyD4Y8gnnYzT3EXKtKJQDgSX/MpGOvKL0WdGP2r4rw7iNn7D5lTx
+kDVwH/jCSRchZBGfzm7xzcnSWtpyPCgpXDGnOXECgYEAyqDrBeKlUDDltoe6xs4K
+gEG+V5E5cwZqvSoOlYHqbtP9Dms6z6G8TvPZblwlbgwXFofrd5LN/vK3pZPiU5Y+
+sd7MhWnjKf7EX9GJD0VhLabFY/KrloJkyL7gOY21xFvmnNqwvH60eOxbVPzlYjaN
+96rK6qkqEdUgXj0CpJZHAMw=
+-----END PRIVATE KEY-----');
+
 		$this->keyManager->expects($this->once())
 			->method('getKey')
 			->with($user)
@@ -549,10 +612,6 @@ class PushTest extends TestCase {
 		$push->expects($this->once())
 			->method('filterByTokenAge')
 			->willReturnArgument(0);
-
-		$push->expects($this->exactly(6))
-			->method('encryptAndSign')
-			->willReturn(['Payload']);
 
 		$push->expects($this->never())
 			->method('deleteProxyPushToken');

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -38,8 +38,6 @@
       <code><![CDATA[$this->keyManager]]></code>
       <code><![CDATA[$this->tokenProvider]]></code>
       <code><![CDATA[ClientException]]></code>
-      <code><![CDATA[Key]]></code>
-      <code><![CDATA[Key]]></code>
       <code><![CDATA[ServerException]]></code>
       <code><![CDATA[protected]]></code>
       <code><![CDATA[protected]]></code>


### PR DESCRIPTION
* Ref https://github.com/nextcloud/notifications/issues/3035

Neither psalm, nor our unit tests caught the issue above. This PR:
* Extends the unit tests in a way that it would have failed
* Changes the methods signature so they are discoverable by psalm (see https://github.com/vimeo/psalm/issues/11864, no `UnknownClass` as method parameter) which would have caught the mistake as well now.
* Adjust the methods so psalm is happy
* Removes an unused parameter in `encryptAndSign`