### PR TITLE
fix(webpush): Don't reuse query object for second query

### DIFF
--- a/lib/Controller/WebPushController.php
+++ b/lib/Controller/WebPushController.php
@@ -298,6 +298,8 @@ class WebPushController extends OCSController {
 		if ($row['activated']) {
 			return ActivationSubStatus::OK;
 		}
+
+		$query = $this->db->getQueryBuilder();
 		$query->update('notifications_webpush')
 			->set('activated', $query->createNamedParameter(true))
 			->where($query->expr()->eq('uid', $query->createNamedParameter($user->getUID())))


### PR DESCRIPTION
Previously logs the following warning:
> "Using where() on non-empty WHERE part, please verify it is intentional to not call andWhere() or orWhere() instead. Otherwise consider creating a new query builder object or call resetQueryPart('where') first.


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
