### PR TITLE
[stable33] fix: Subject in encrypt method

### DIFF
--- a/lib/Push.php
+++ b/lib/Push.php
@@ -621,11 +621,9 @@ class Push {
 			'id' => $notification->getObjectId(),
 		];
 
-		$jsonData = (string)json_encode($data);
-
 		// Max length of encryption is ~240, so we need to make sure the subject is shorter.
 		// Also, subtract two for encapsulating quotes will be added.
-		$maxDataLength = 200 - strlen($jsonData) - 2;
+		$maxDataLength = 200 - strlen((string)json_encode($data)) - 2;
 		$data['subject'] = Util::shortenMultibyteString($notification->getParsedSubject(), $maxDataLength);
 		if ($notification->getParsedSubject() !== $data['subject']) {
 			$data['subject'] .= '…';
@@ -641,6 +639,8 @@ class Push {
 			$priority = 'normal';
 			$type = 'alert';
 		}
+
+		$jsonData = (string)json_encode($data);
 
 		$this->printInfo('Device public key size: ' . strlen($device['devicepublickey']));
 		$this->printInfo('Data to encrypt is: ' . $jsonData);


### PR DESCRIPTION
Before (subject empty)

> Data to encrypt is: {"nid":163098,"app":"admin_notifications","subject":"","type":"admin_notifications","id":"6a393593"}

After 

> Data to encrypt is: {"nid":163099,"app":"admin_notifications","subject":"Testing push notifications","type":"admin_notifications","id":"6a3935bd"}

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
