### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@
 📣 Announcement center: An announcement was posted by an admin]]></description>
 
 	<version>8.0.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-only</licence>
 	<author>Joas Schilling</author>
 
 	<types>

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	},
 	"name": "nextcloud/notifications",
 	"description": "notifications",
-	"license": "AGPL",
+	"license": "AGPL-3.0-only",
 	"config": {
 		"optimize-autoloader": true,
 		"classmap-authoritative": true,


### PR DESCRIPTION
unifying the license string, already used in package.json and supported in info.xml since 31, so no issue given min-version is set to 35 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
