### PR TITLE
[stable34] Update nextcloud/ocp dependency

### DIFF
--- a/vendor-bin/nextcloud-ocp/composer.lock
+++ b/vendor-bin/nextcloud-ocp/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "2dcb60c95021914893db2776207bfacc4226f7d1"
+                "reference": "81cbb2c594afe0fa978885bf7accd0440199520a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/2dcb60c95021914893db2776207bfacc4226f7d1",
-                "reference": "2dcb60c95021914893db2776207bfacc4226f7d1",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/81cbb2c594afe0fa978885bf7accd0440199520a",
+                "reference": "81cbb2c594afe0fa978885bf7accd0440199520a",
                 "shasum": ""
             },
             "require": {
@@ -54,7 +54,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable34"
             },
-            "time": "2026-07-15T01:17:58+00:00"
+            "time": "2026-07-16T01:28:13+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency