### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "3f7a7a7bd69d0864de6fb72561f4be83dd2a3d08"
+                "reference": "8afc39ced79894f44ca22ffe34838311831d9683"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/3f7a7a7bd69d0864de6fb72561f4be83dd2a3d08",
-                "reference": "3f7a7a7bd69d0864de6fb72561f4be83dd2a3d08",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8afc39ced79894f44ca22ffe34838311831d9683",
+                "reference": "8afc39ced79894f44ca22ffe34838311831d9683",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-08-06T01:25:05+00:00"
+            "time": "2026-08-07T02:03:41+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency