### PR TITLE
[master] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -15,10 +15,10 @@ ab3a506506b1d7c1cea9593ecfd84366 lint-stylelint.yml
 03759c9dc0fa748cb927b9f9cadf2925 node.yml
 0dc931ec237a235370e224282608b20e npm-audit-fix.yml
 b45e44d9ffe39586b38b6a925c1a9740 openapi.yml
-4ced3302b18f5a32829eadde7a02400c phpunit-mysql.yml
-02dde22c83fc396f4f566f589494486f phpunit-oci.yml
-c3d489abcf3148e277f023afaa9e2182 phpunit-pgsql.yml
-e86927ad532dd0eb6b20f3a48274cc82 phpunit-sqlite.yml
+3cacf28a710b387e83d3858af40b7ffe phpunit-mysql.yml
+f89c18551d6a29af9bca63a0fd30a039 phpunit-oci.yml
+12a43f55ac6aedc321b62e00f9d864f0 phpunit-pgsql.yml
+ba5a538fea1a9e53dfcbeb53b83ea6fa phpunit-sqlite.yml
 aaa395a26591445ccf4c8196d7f01ee7 pr-feedback.yml
 4f1080b33778a956a08efc7a41a11994 psalm.yml
 2dbec18233063b42f4d8e03bbb43671c reuse.yml

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -18,30 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
-    runs-on: ubuntu-latest-low
-    outputs:
-      matrix: ${{ steps.versions.outputs.sparse-matrix }}
-    steps:
-      - name: Checkout app
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Get version matrix
-        id: versions
-        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
-        with:
-          matrix: '{"mysql-versions": ["8.4"]}'
-
-  changes:
+  changes-and-matrix:
     runs-on: ubuntu-latest-low
     permissions:
       contents: read
       pull-requests: read
 
     outputs:
-      src: ${{ steps.changes.outputs.src}}
+      src: ${{ steps.changes.outputs.src }}
+      matrix: ${{ steps.versions.outputs.sparse-matrix }}
 
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -61,15 +46,28 @@ jobs:
               - 'composer.json'
               - 'composer.lock'
 
+      - name: Checkout app
+        if: steps.changes.outputs.src != 'false'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        if: steps.changes.outputs.src != 'false'
+        id: versions
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
+        with:
+          matrix: '{"mysql-versions": ["8.4"]}'
+
   phpunit-mysql:
     runs-on: ubuntu-latest
 
-    needs: [changes, matrix]
-    if: needs.changes.outputs.src != 'false'
+    needs: changes-and-matrix
+    if: needs.changes-and-matrix.outputs.src != 'false'
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.changes-and-matrix.outputs.matrix) }}
 
     name: MySQL ${{ matrix.mysql-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 
@@ -200,7 +198,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, phpunit-mysql]
+    needs: [changes-and-matrix, phpunit-mysql]
 
     if: always()
 
@@ -208,4 +206,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-mysql.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes-and-matrix.outputs.src != 'false' && needs.phpunit-mysql.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -18,22 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
-    runs-on: ubuntu-latest-low
-    outputs:
-      php-version: ${{ steps.versions.outputs.php-available-list }}
-      server-max: ${{ steps.versions.outputs.branches-max-list }}
-    steps:
-      - name: Checkout app
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Get version matrix
-        id: versions
-        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
-
-  changes:
+  changes-and-matrix:
     runs-on: ubuntu-latest-low
     permissions:
       contents: read
@@ -41,6 +26,8 @@ jobs:
 
     outputs:
       src: ${{ steps.changes.outputs.src }}
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
 
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -60,17 +47,28 @@ jobs:
               - 'composer.json'
               - 'composer.lock'
 
+      - name: Checkout app
+        if: steps.changes.outputs.src != 'false'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        if: steps.changes.outputs.src != 'false'
+        id: versions
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
+
   phpunit-oci:
     runs-on: ubuntu-latest
 
-    needs: [changes, matrix]
-    if: needs.changes.outputs.src != 'false'
+    needs: changes-and-matrix
+    if: needs.changes-and-matrix.outputs.src != 'false'
 
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
-        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+        php-versions: ${{ fromJson(needs.changes-and-matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.changes-and-matrix.outputs.server-max) }}
         oci-versions: ['18', '21', '23']
 
     name: OCI ${{ matrix.oci-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
@@ -207,7 +205,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, phpunit-oci]
+    needs: [changes-and-matrix, phpunit-oci]
 
     if: always()
 
@@ -215,4 +213,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-oci.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes-and-matrix.outputs.src != 'false' && needs.phpunit-oci.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -18,22 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
-    runs-on: ubuntu-latest-low
-    outputs:
-      php-version: ${{ steps.versions.outputs.php-available-list }}
-      server-max: ${{ steps.versions.outputs.branches-max-list }}
-    steps:
-      - name: Checkout app
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Get version matrix
-        id: versions
-        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
-
-  changes:
+  changes-and-matrix:
     runs-on: ubuntu-latest-low
     permissions:
       contents: read
@@ -41,6 +26,8 @@ jobs:
 
     outputs:
       src: ${{ steps.changes.outputs.src }}
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
 
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -60,17 +47,28 @@ jobs:
               - 'composer.json'
               - 'composer.lock'
 
+      - name: Checkout app
+        if: steps.changes.outputs.src != 'false'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        if: steps.changes.outputs.src != 'false'
+        id: versions
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
+
   phpunit-pgsql:
     runs-on: ubuntu-latest
 
-    needs: [changes, matrix]
-    if: needs.changes.outputs.src != 'false'
+    needs: changes-and-matrix
+    if: needs.changes-and-matrix.outputs.src != 'false'
 
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
-        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+        php-versions: ${{ fromJson(needs.changes-and-matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.changes-and-matrix.outputs.server-max) }}
 
     name: PostgreSQL PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 
@@ -198,7 +196,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, phpunit-pgsql]
+    needs: [changes-and-matrix, phpunit-pgsql]
 
     if: always()
 
@@ -206,4 +204,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-pgsql.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes-and-matrix.outputs.src != 'false' && needs.phpunit-pgsql.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -18,29 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  matrix:
-    runs-on: ubuntu-latest-low
-    outputs:
-      php-version: ${{ steps.versions.outputs.php-available-list }}
-      server-max: ${{ steps.versions.outputs.branches-max-list }}
-    steps:
-      - name: Checkout app
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Get version matrix
-        id: versions
-        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
-
-  changes:
+  changes-and-matrix:
     runs-on: ubuntu-latest-low
     permissions:
       contents: read
       pull-requests: read
 
     outputs:
-      src: ${{ steps.changes.outputs.src}}
+      src: ${{ steps.changes.outputs.src }}
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
 
     steps:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
@@ -60,17 +47,28 @@ jobs:
               - 'composer.json'
               - 'composer.lock'
 
+      - name: Checkout app
+        if: steps.changes.outputs.src != 'false'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        if: steps.changes.outputs.src != 'false'
+        id: versions
+        uses: nextcloud-libraries/nextcloud-version-matrix@cd0211ffcef1065e2020cd579e4843b8746e7a58 # v1.3.3
+
   phpunit-sqlite:
     runs-on: ubuntu-latest
 
-    needs: [changes, matrix]
-    if: needs.changes.outputs.src != 'false'
+    needs: changes-and-matrix
+    if: needs.changes-and-matrix.outputs.src != 'false'
 
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
-        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+        php-versions: ${{ fromJson(needs.changes-and-matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.changes-and-matrix.outputs.server-max) }}
 
     name: SQLite PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 
@@ -187,7 +185,7 @@ jobs:
     permissions:
       contents: none
     runs-on: ubuntu-latest-low
-    needs: [changes, phpunit-sqlite]
+    needs: [changes-and-matrix, phpunit-sqlite]
 
     if: always()
 
@@ -195,4 +193,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-sqlite.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes-and-matrix.outputs.src != 'false' && needs.phpunit-sqlite.result != 'success' }}; then exit 1; fi


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [phpunit-mysql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-mysql.yml)
  - Patch applied
- 🆙 Updated [phpunit-oci.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-oci.yml)
  - Patch applied
- 🆙 Updated [phpunit-pgsql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-pgsql.yml)
  - Patch applied
- 🆙 Updated [phpunit-sqlite.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-sqlite.yml)
  - Patch applied